### PR TITLE
JDK-8278516: Typos in snippet for java.compiler

### DIFF
--- a/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
+++ b/src/java.compiler/share/classes/javax/tools/StandardJavaFileManager.java
@@ -76,8 +76,8 @@ import java.util.List;
  *         must succeed if the following would succeed (ignoring
  *         encoding issues):
  *         {@snippet id="equiv-input" lang=java :
- *             // @link substring=FileInputStream target="java.io.FileInputStream#FileInputStream(File)" @link regex="File\b" target="File#File(java.net.URI)" @link substring=fileObject target=FileObject @link substring=toURI target="FileObject#toUri()" :
- *             new FileInputStream(new File(fileObject.toURI()))
+ *             // @link substring=FileInputStream target="java.io.FileInputStream#FileInputStream(File)" @link regex="File\b" target="File#File(java.net.URI)" @link substring=fileObject target=FileObject @link substring=toUri target="FileObject#toUri()" :
+ *             new FileInputStream(new File(fileObject.toUri()))
  *             }
  *       </li>
  *       <li>
@@ -87,8 +87,8 @@ import java.util.List;
  *         succeed if the following would succeed (ignoring encoding
  *         issues):
  *         {@snippet id="equiv-output" lang=java :
- *             // @link substring=FileOutputStream target="java.io.FileOutputStream#FileOutputStream(File)" @link regex="File\b" target="File#File(java.net.URI)" @link substring=fileObject target=FileObject @link substring=toURI target="FileObject#toUri()" :
- *             new FileOutputStream(new File(fileObject.toURI()))
+ *             // @link substring=FileOutputStream target="java.io.FileOutputStream#FileOutputStream(File)" @link regex="File\b" target="File#File(java.net.URI)" @link substring=fileObject target=FileObject @link substring=toUri target="FileObject#toUri()" :
+ *             new FileOutputStream(new File(fileObject.toUri()))
  *             }
  *       </li>
  *     </ul>


### PR DESCRIPTION
Please review a trivial update to replace some instances of `toURI` with `toUri` that were accidentally introduced when converting some code to use snippets.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278516](https://bugs.openjdk.java.net/browse/JDK-8278516): Typos in snippet for java.compiler


### Reviewers
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/2.diff">https://git.openjdk.java.net/jdk18/pull/2.diff</a>

</details>
