### PR TITLE
JDK-8278538: Test langtools/jdk/javadoc/tool/CheckManPageOptions.java fails after the manpage was updated

### DIFF
--- a/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
+++ b/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8274211
+ * @bug 8274211 8278538
  * @summary Test man page that options are documented
  * @modules jdk.javadoc/jdk.javadoc.internal.tool:+open
  * @run main CheckManPageOptions
@@ -60,16 +60,7 @@ public class CheckManPageOptions {
 
     static final PrintStream out = System.err;
 
-    // FIXME: JDK-8274295, JDK-8266666, JDK-8278077
-    List<String> MISSING_IN_MAN_PAGE = List.of(
-            "--add-script",
-            "--legal-notices",
-            "--link-modularity-mismatch",
-            "--link-platform-properties",
-            "--no-platform-links",
-            "--since",
-            "--since-label",
-            "--snippet-path");
+    List<String> MISSING_IN_MAN_PAGE = List.of();
 
     void run(String... args) throws Exception {
         var file = args.length == 0 ? findDefaultFile() : Path.of(args[0]);


### PR DESCRIPTION
Please review a fix to update this test to match the latest man page

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278538](https://bugs.openjdk.java.net/browse/JDK-8278538): Test langtools/jdk/javadoc/tool/CheckManPageOptions.java fails after the manpage was updated


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/8.diff">https://git.openjdk.java.net/jdk18/pull/8.diff</a>

</details>
