### PR TITLE
8278389: SuspendibleThreadSet::_suspend_all should be volatile/atomic

### DIFF
--- a/src/hotspot/share/gc/shared/suspendibleThreadSet.hpp
+++ b/src/hotspot/share/gc/shared/suspendibleThreadSet.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_SHARED_SUSPENDIBLETHREADSET_HPP
 
 #include "memory/allocation.hpp"
+#include "runtime/atomic.hpp"
 
 // A SuspendibleThreadSet is a set of threads that can be suspended.
 // A thread can join and later leave the set, and periodically yield.
@@ -40,9 +41,10 @@ class SuspendibleThreadSet : public AllStatic {
   friend class SuspendibleThreadSetLeaver;
 
 private:
+  static volatile bool _suspend_all;
+
   static uint   _nthreads;
   static uint   _nthreads_stopped;
-  static bool   _suspend_all;
   static double _suspend_all_start;
 
   static bool is_synchronized();
@@ -53,9 +55,11 @@ private:
   // Removes the current thread from the set.
   static void leave();
 
+  static bool suspend_all() { return Atomic::load(&_suspend_all); }
+
 public:
   // Returns true if an suspension is in progress.
-  static bool should_yield() { return _suspend_all; }
+  static bool should_yield() { return suspend_all(); }
 
   // Suspends the current thread if a suspension is in progress.
   static void yield();


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that makes `SuspendibleThreadSet::_suspend_all` volatile and all accesses to it use `Atomic` helpers?

I found that the only getter for that member is called `SuspendibleThreadSet::should_yield()`, which contradicts our naming rules; to keep the change minimal (and the naming discussion out of this PR because I do not feel that `_suspend_all` is particularly good) I introduced a private `suspend_all()` method.
I can of course add some renaming in this change (but then for jdk19+ only).

Testing: gha, local compilation

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8278389](https://bugs.openjdk.java.net/browse/JDK-8278389): SuspendibleThreadSet::_suspend_all should be volatile/atomic


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/9/head:pull/9` \
`$ git checkout pull/9`

Update a local copy of the PR: \
`$ git checkout pull/9` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/9/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 9`

View PR using the GUI difftool: \
`$ git pr show -t 9`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/9.diff">https://git.openjdk.java.net/jdk18/pull/9.diff</a>

</details>
