### PR TITLE
8278389: SuspendibleThreadSet::_suspend_all should be volatile/atomic

### DIFF
--- a/src/hotspot/share/gc/shared/suspendibleThreadSet.cpp
+++ b/src/hotspot/share/gc/shared/suspendibleThreadSet.cpp
@@ -50,7 +50,7 @@ bool SuspendibleThreadSet::is_synchronized() {
 void SuspendibleThreadSet::join() {
   assert(!Thread::current()->is_suspendible_thread(), "Thread already joined");
   MonitorLocker ml(STS_lock, Mutex::_no_safepoint_check_flag);
-  while (suspend_all()) {
+  while (suspend_ all()) {
     ml.wait();
   }
   _nthreads++;

--- a/src/hotspot/share/gc/shared/suspendibleThreadSet.cpp
+++ b/src/hotspot/share/gc/shared/suspendibleThreadSet.cpp
@@ -50,7 +50,7 @@ bool SuspendibleThreadSet::is_synchronized() {
 void SuspendibleThreadSet::join() {
   assert(!Thread::current()->is_suspendible_thread(), "Thread already joined");
   MonitorLocker ml(STS_lock, Mutex::_no_safepoint_check_flag);
-  while (suspend_ all()) {
+  while (suspend_all()) {
     ml.wait();
   }
   _nthreads++;

--- a/src/hotspot/share/gc/shared/suspendibleThreadSet.hpp
+++ b/src/hotspot/share/gc/shared/suspendibleThreadSet.hpp
@@ -26,6 +26,7 @@
 #define SHARE_GC_SHARED_SUSPENDIBLETHREADSET_HPP
 
 #include "memory/allocation.hpp"
+#include "runtime/atomic.hpp"
 
 // A SuspendibleThreadSet is a set of threads that can be suspended.
 // A thread can join and later leave the set, and periodically yield.
@@ -40,9 +41,10 @@ class SuspendibleThreadSet : public AllStatic {
   friend class SuspendibleThreadSetLeaver;
 
 private:
+  static volatile bool _suspend_all;
+
   static uint   _nthreads;
   static uint   _nthreads_stopped;
-  static bool   _suspend_all;
   static double _suspend_all_start;
 
   static bool is_synchronized();
@@ -53,9 +55,11 @@ private:
   // Removes the current thread from the set.
   static void leave();
 
+  static bool suspend_all() { return Atomic::load(&_suspend_all); }
+
 public:
   // Returns true if an suspension is in progress.
-  static bool should_yield() { return _suspend_all; }
+  static bool should_yield() { return suspend_all(); }
 
   // Suspends the current thread if a suspension is in progress.
   static void yield();

--- a/src/hotspot/share/gc/shared/suspendibleThreadSet.hpp
+++ b/src/hotspot/share/gc/shared/suspendibleThreadSet.hpp
@@ -47,7 +47,7 @@ private:
   static uint   _nthreads_stopped;
   static double _suspend_all_start;
 
-  static bool is_synchronized();
+  static bool _is_synchronized();
 
   // Add the current thread to the set. May block if a suspension is in progress.
   static void join();

--- a/src/hotspot/share/gc/shared/suspendibleThreadSet.hpp
+++ b/src/hotspot/share/gc/shared/suspendibleThreadSet.hpp
@@ -47,7 +47,7 @@ private:
   static uint   _nthreads_stopped;
   static double _suspend_all_start;
 
-  static bool _is_synchronized();
+  static bool is_synchronized();
 
   // Add the current thread to the set. May block if a suspension is in progress.
   static void join();


### PR DESCRIPTION
Hi all,

can I have reviews for this change that makes SuspendibleThreadSet::_suspend_all volatile and all accesses to it use Atomic helpers?

I found that the only getter for that member is called SuspendibleThreadSet::should_yield(), which contradicts our naming rules; to keep the change minimal (and the naming discussion out of this PR because I do not feel that _suspend_all is particularly good) I introduced a private suspend_all() method.
I can of course add some renaming in this change (but then for jdk19+ only).

Testing: gha, local compilation

Thanks,
Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278389](https://bugs.openjdk.java.net/browse/JDK-8278389): SuspendibleThreadSet::_suspend_all should be volatile/atomic


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.java.net/census#ayang) (@albertnetymk - **Reviewer**)
 * [Hamlin Li](https://openjdk.java.net/census#mli) (@Hamlin-Li - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/10.diff">https://git.openjdk.java.net/jdk18/pull/10.diff</a>

</details>
