### PR TITLE
8132785: java/lang/management/ThreadMXBean/ThreadLists.java fails intermittently

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -567,7 +567,6 @@ com/sun/management/OperatingSystemMXBean/GetSystemCpuLoad.java  8030957 aix-all
 java/lang/management/MemoryMXBean/Pending.java                  8158837 generic-all
 java/lang/management/MemoryMXBean/PendingAllGC.sh               8158837 generic-all
 java/lang/management/ThreadMXBean/ThreadMXBeanStateTest.java    8247426 generic-all
-java/lang/management/ThreadMXBean/ThreadLists.java              8132785 generic-all
 
 sun/management/jdp/JdpDefaultsTest.java                         8241865 linux-aarch64,macosx-all
 sun/management/jdp/JdpJmxRemoteDynamicPortTest.java             8241865 macosx-all

--- a/test/jdk/java/lang/management/ThreadMXBean/ThreadLists.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/ThreadLists.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2015, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2021, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,9 +23,11 @@
 
 /*
  * @test
- * @bug 5047639
+ * @bug 5047639 8132785
  * @summary Check that the "java-level" APIs provide a consistent view of
  *          the thread list
+ * @comment Must run in othervm mode to avoid interference from other tests.
+ * @run main/othervm ThreadLists
  */
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
@@ -50,6 +52,19 @@ public class ThreadLists {
         // get the thread count
         int activeCount = top.activeCount();
 
+        // Now enumerate to see if we find any extras yet.
+        // Ensure the array is big enough for a few extras.
+        Thread[] threads = new Thread[activeCount * 2];
+        int newCount = top.enumerate(threads);
+	if (newCount != activeCount) {
+            System.out.println("Found different threads after enumeration:");
+        } else {
+            System.out.println("Initial set of enumerated threads:");
+        }
+        for (int i = 0; i < newCount; i++) {
+            System.out.println(" - Thread: " + threads[i].getName());
+        }
+
         Map<Thread, StackTraceElement[]> stackTraces = Thread.getAllStackTraces();
 
         ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
@@ -68,6 +83,11 @@ public class ThreadLists {
         if (activeCount != threadIds.length) failed = true;
 
         if (failed) {
+            System.out.println("Set of stack-traced threads:");
+            for (Thread t : stackTraces.keySet()) {
+                System.out.println(" - Thread: " +
+                                   (t != null ? t.getName() : "null!"));
+            }
             throw new RuntimeException("inconsistent results");
         }
     }

--- a/test/jdk/java/lang/management/ThreadMXBean/ThreadLists.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/ThreadLists.java
@@ -56,7 +56,7 @@ public class ThreadLists {
         // Ensure the array is big enough for a few extras.
         Thread[] threads = new Thread[activeCount * 2];
         int newCount = top.enumerate(threads);
-	if (newCount != activeCount) {
+        if (newCount != activeCount) {
             System.out.println("Found different threads after enumeration:");
         } else {
             System.out.println("Initial set of enumerated threads:");


### PR DESCRIPTION
Investigation showed this test was experiencing interference from threads created by other tests in agentvm mode. The simple solution is to run this test isolated using othervm mode. Also added some diagnostics to the test incase we see future failures.

Testing: local and tier3.

Thanks,
David

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8132785](https://bugs.openjdk.java.net/browse/JDK-8132785): java/lang/management/ThreadMXBean/ThreadLists.java fails intermittently


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Kevin Walls](https://openjdk.java.net/census#kevinw) (@kevinjwalls - Committer)
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/14.diff">https://git.openjdk.java.net/jdk18/pull/14.diff</a>

</details>
