### PR TITLE
8278489: Preserve result in native wrapper with +UseHeavyMonitors

### DIFF
--- a/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/sharedRuntime_aarch64.cpp
@@ -1783,13 +1783,14 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       // Simple recursive lock?
       __ ldr(rscratch1, Address(sp, lock_slot_offset * VMRegImpl::stack_slot_size));
       __ cbz(rscratch1, done);
+    }
 
-      // Must save r0 if if it is live now because cmpxchg must use it
-      if (ret_type != T_FLOAT && ret_type != T_DOUBLE && ret_type != T_VOID) {
-        save_native_result(masm, ret_type, stack_slots);
-      }
+    // Must save r0 if if it is live now because cmpxchg must use it
+    if (ret_type != T_FLOAT && ret_type != T_DOUBLE && ret_type != T_VOID) {
+      save_native_result(masm, ret_type, stack_slots);
+    }
 
-
+    if (!UseHeavyMonitors) {
       // get address of the stack lock
       __ lea(r0, Address(sp, lock_slot_offset * VMRegImpl::stack_slot_size));
       //  get old displaced header

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -1862,12 +1862,14 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
       __ cmpptr(Address(rbp, lock_slot_rbp_offset), (int32_t)NULL_WORD);
       __ jcc(Assembler::equal, done);
+    }
 
-      // Must save rax, if if it is live now because cmpxchg must use it
-      if (ret_type != T_FLOAT && ret_type != T_DOUBLE && ret_type != T_VOID) {
-        save_native_result(masm, ret_type, stack_slots);
-      }
+    // Must save rax, if if it is live now because cmpxchg must use it
+     if (ret_type != T_FLOAT && ret_type != T_DOUBLE && ret_type != T_VOID) {
+       save_native_result(masm, ret_type, stack_slots);
+     }
 
+    if (!UseHeavyMonitors) {
       //  get old displaced header
       __ movptr(rbx, Address(rbp, lock_slot_rbp_offset));
 

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_32.cpp
@@ -1864,10 +1864,10 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ jcc(Assembler::equal, done);
     }
 
-    // Must save rax, if if it is live now because cmpxchg must use it
-     if (ret_type != T_FLOAT && ret_type != T_DOUBLE && ret_type != T_VOID) {
-       save_native_result(masm, ret_type, stack_slots);
-     }
+    // Must save rax, if it is live now because cmpxchg must use it
+    if (ret_type != T_FLOAT && ret_type != T_DOUBLE && ret_type != T_VOID) {
+      save_native_result(masm, ret_type, stack_slots);
+    }
 
     if (!UseHeavyMonitors) {
       //  get old displaced header

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2066,7 +2066,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       __ jcc(Assembler::equal, done);
     }
 
-    // Must save rax if if it is live now because cmpxchg must use it
+    // Must save rax if it is live now because cmpxchg must use it
     if (ret_type != T_FLOAT && ret_type != T_DOUBLE && ret_type != T_VOID) {
       save_native_result(masm, ret_type, stack_slots);
     }

--- a/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
+++ b/src/hotspot/cpu/x86/sharedRuntime_x86_64.cpp
@@ -2064,13 +2064,15 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       // Simple recursive lock?
       __ cmpptr(Address(rsp, lock_slot_offset * VMRegImpl::stack_slot_size), (int32_t)NULL_WORD);
       __ jcc(Assembler::equal, done);
+    }
 
-      // Must save rax if if it is live now because cmpxchg must use it
-      if (ret_type != T_FLOAT && ret_type != T_DOUBLE && ret_type != T_VOID) {
-        save_native_result(masm, ret_type, stack_slots);
-      }
+    // Must save rax if if it is live now because cmpxchg must use it
+    if (ret_type != T_FLOAT && ret_type != T_DOUBLE && ret_type != T_VOID) {
+      save_native_result(masm, ret_type, stack_slots);
+    }
 
 
+    if (!UseHeavyMonitors) {
       // get address of the stack lock
       __ lea(rax, Address(rsp, lock_slot_offset * VMRegImpl::stack_slot_size));
       //  get old displaced header


### PR DESCRIPTION
Testing observed a few failures after JDK-8276901. The reason for the failures is in the native-wrappers, in the +UseHeavyMonitors paths, we don't preserve the result register after the native call.

Testing:
 - [x] java/awt/color, sun/java2d/cmm tests (x86_32, x86_64, aarch64 x -UseHeavyMonitors, +UseHeavyMonitors)
 - [x] tier1 (x86_32, x86_64, aarch64 x -UseHeavyMonitors, +UseHeavyMonitors)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278489](https://bugs.openjdk.java.net/browse/JDK-8278489): Preserve result in native wrapper with +UseHeavyMonitors


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/16.diff">https://git.openjdk.java.net/jdk18/pull/16.diff</a>

</details>
