### PR TITLE
8278233: [macos] tools/jpackage tests timeout due to /usr/bin/osascript

### DIFF
--- a/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
+++ b/src/jdk.jpackage/share/classes/jdk/jpackage/internal/IOUtils.java
@@ -191,7 +191,7 @@ public class IOUtils {
             PrintStream consumer, boolean writeOutputToFile, long timeout)
             throws IOException {
         exec(pb, testForPresenceOnly, consumer, writeOutputToFile,
-                Executor.INFINITE_TIMEOUT, false);
+                timeout, false);
     }
 
     static void exec(ProcessBuilder pb, boolean testForPresenceOnly,

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -835,9 +835,6 @@ jdk/jfr/api/consumer/streaming/TestLatestEvent.java             8268297 windows-
 
 # jdk_jpackage
 
-tools/jpackage/share/IconTest.java 8278233 macosx-x64
-tools/jpackage/share/MultiNameTwoPhaseTest.java 8278233 macosx-x64
-
 ############################################################################
 
 # Client manual tests


### PR DESCRIPTION
This is regression from JDK-8276837. exec() was passing INFINITE_TIMEOUT instead of actual value of timeout variable. Execution of osascript was running without timeout and thus several tests timeout. Osascript hang during test execution is intermittent issue.

Also, removed IconTest.java and MultiNameTwoPhaseTest.java from ProblemList.txt.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278233](https://bugs.openjdk.java.net/browse/JDK-8278233): [macos] tools/jpackage tests timeout due to /usr/bin/osascript


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/18.diff">https://git.openjdk.java.net/jdk18/pull/18.diff</a>

</details>
