### PR TITLE
8274323: compiler/codegen/aes/TestAESMain.java failed with "Error: invalid offset: -1434443640" after 8273297

### DIFF
--- a/src/hotspot/cpu/aarch64/matcher_aarch64.hpp
+++ b/src/hotspot/cpu/aarch64/matcher_aarch64.hpp
@@ -55,9 +55,6 @@
   // No support for generic vector operands.
   static const bool supports_generic_vector_operands = false;
 
-  // No support for 48 extra htbl entries in aes-gcm intrinsic
-  static const int htbl_entries = 0;
-
   static constexpr bool isSimpleConstant64(jlong value) {
     // Will one (StoreL ConL) be cheaper than two (StoreI ConI)?.
     // Probably always true, even if a temp register is required.

--- a/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/stubGenerator_aarch64.cpp
@@ -3094,8 +3094,7 @@ class StubGenerator: public StubCodeGenerator {
   // key = c_rarg4
   // state = c_rarg5 - GHASH.state
   // subkeyHtbl = c_rarg6 - powers of H
-  // subkeyHtbl_48_entries = c_rarg7 (not used)
-  // counter = [sp, #0] pointer to 16 bytes of CTR
+  // counter = c_rarg7 - 16 bytes of CTR
   // return - number of processed bytes
   address generate_galoisCounterMode_AESCrypt() {
     address ghash_polynomial = __ pc();
@@ -3121,10 +3120,7 @@ class StubGenerator: public StubCodeGenerator {
 
     const Register subkeyHtbl = c_rarg6;
 
-    // Pointer to CTR is passed on the stack before the (fp, lr) pair.
-    const Address counter_mem(sp, 2 * wordSize);
     const Register counter = c_rarg7;
-    __ ldr(counter, counter_mem);
 
     const Register keylen = r10;
     // Save state before entering routine

--- a/src/hotspot/cpu/arm/matcher_arm.hpp
+++ b/src/hotspot/cpu/arm/matcher_arm.hpp
@@ -56,9 +56,6 @@
   // No support for generic vector operands.
   static const bool supports_generic_vector_operands = false;
 
-  // No support for 48 extra htbl entries in aes-gcm intrinsic
-  static const int htbl_entries = -1;
-
   static constexpr bool isSimpleConstant64(jlong value) {
     // Will one (StoreL ConL) be cheaper than two (StoreI ConI)?.
     return false;

--- a/src/hotspot/cpu/ppc/matcher_ppc.hpp
+++ b/src/hotspot/cpu/ppc/matcher_ppc.hpp
@@ -57,9 +57,6 @@
   // No support for generic vector operands.
   static const bool supports_generic_vector_operands = false;
 
-  // No support for 48 extra htbl entries in aes-gcm intrinsic
-  static const int htbl_entries = -1;
-
   static constexpr bool isSimpleConstant64(jlong value) {
     // Probably always true, even if a temp register is required.
     return true;

--- a/src/hotspot/cpu/s390/matcher_s390.hpp
+++ b/src/hotspot/cpu/s390/matcher_s390.hpp
@@ -57,9 +57,6 @@
   // No support for generic vector operands.
   static const bool supports_generic_vector_operands = false;
 
-  // No support for 48 extra htbl entries in aes-gcm intrinsic
-  static const int htbl_entries = -1;
-
   static constexpr bool isSimpleConstant64(jlong value) {
     // Probably always true, even if a temp register is required.
     return true;

--- a/src/hotspot/cpu/x86/matcher_x86.hpp
+++ b/src/hotspot/cpu/x86/matcher_x86.hpp
@@ -148,8 +148,6 @@
   static const bool int_in_long = false;
 #endif
 
-  // Number of htbl entries for aes-gcm intrinsic
-  static const int htbl_entries = 96;
 
   // Does the CPU supports vector variable shift instructions?
   static bool supports_vector_variable_shifts(void) {

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4441,14 +4441,21 @@ class StubGenerator: public StubCodeGenerator {
     __ movptr(key, key_mem);
     __ movptr(state, state_mem);
 #endif
-    __ subptr(rsp, 96 * longSize); // Create space on the stack for htbl entries
     __ movptr(subkeyHtbl, subkeyH_mem);
-    __ movptr(avx512_subkeyHtbl, rsp);
     __ movptr(counter, counter_mem);
+// Save rbp and rsp
+    __ push(rbp);
+    __ movq(rbp, rsp);
+// Align stack
+    __ andq(rsp, -64);
+    __ subptr(rsp, 96 * longSize); // Create space on the stack for htbl entries
+    __ movptr(avx512_subkeyHtbl, rsp);
 
     __ aesgcm_encrypt(in, len, ct, out, key, state, subkeyHtbl, avx512_subkeyHtbl, counter);
 
     __ addptr(rsp, 96 * longSize);
+    __ movq(rsp, rbp);
+    __ pop(rbp);
 
     // Restore state before leaving routine
 #ifdef _WIN64

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4453,7 +4453,6 @@ class StubGenerator: public StubCodeGenerator {
 
     __ aesgcm_encrypt(in, len, ct, out, key, state, subkeyHtbl, avx512_subkeyHtbl, counter);
 
-    __ addptr(rsp, 96 * longSize);
     __ movq(rsp, rbp);
     __ pop(rbp);
 

--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4414,9 +4414,8 @@ class StubGenerator: public StubCodeGenerator {
     const Register state = c_rarg5;
     const Address subkeyH_mem(rbp, 2 * wordSize);
     const Register subkeyHtbl = r11;
-    const Address avx512_subkeyH_mem(rbp, 3 * wordSize);
     const Register avx512_subkeyHtbl = r13;
-    const Address counter_mem(rbp, 4 * wordSize);
+    const Address counter_mem(rbp, 3 * wordSize);
     const Register counter = r12;
 #else
     const Address key_mem(rbp, 6 * wordSize);
@@ -4425,9 +4424,8 @@ class StubGenerator: public StubCodeGenerator {
     const Register state = r13;
     const Address subkeyH_mem(rbp, 8 * wordSize);
     const Register subkeyHtbl = r14;
-    const Address avx512_subkeyH_mem(rbp, 9 * wordSize);
     const Register avx512_subkeyHtbl = r12;
-    const Address counter_mem(rbp, 10 * wordSize);
+    const Address counter_mem(rbp, 9 * wordSize);
     const Register counter = rsi;
 #endif
     __ enter();
@@ -4443,11 +4441,14 @@ class StubGenerator: public StubCodeGenerator {
     __ movptr(key, key_mem);
     __ movptr(state, state_mem);
 #endif
+    __ subptr(rsp, 96 * longSize); // Create space on the stack for htbl entries
     __ movptr(subkeyHtbl, subkeyH_mem);
-    __ movptr(avx512_subkeyHtbl, avx512_subkeyH_mem);
+    __ movptr(avx512_subkeyHtbl, rsp);
     __ movptr(counter, counter_mem);
 
     __ aesgcm_encrypt(in, len, ct, out, key, state, subkeyHtbl, avx512_subkeyHtbl, counter);
+
+    __ addptr(rsp, 96 * longSize);
 
     // Restore state before leaving routine
 #ifdef _WIN64

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -2488,8 +2488,7 @@ Node* GraphKit::make_runtime_call(int flags,
                                   Node* parm0, Node* parm1,
                                   Node* parm2, Node* parm3,
                                   Node* parm4, Node* parm5,
-                                  Node* parm6, Node* parm7,
-                                  Node* parm8) {
+                                  Node* parm6, Node* parm7) {
   assert(call_addr != NULL, "must not call NULL targets");
 
   // Slow-path call
@@ -2536,8 +2535,7 @@ Node* GraphKit::make_runtime_call(int flags,
   if (parm5 != NULL) { call->init_req(TypeFunc::Parms+5, parm5);
   if (parm6 != NULL) { call->init_req(TypeFunc::Parms+6, parm6);
   if (parm7 != NULL) { call->init_req(TypeFunc::Parms+7, parm7);
-  if (parm8 != NULL) { call->init_req(TypeFunc::Parms+8, parm8);
-  /* close each nested if ===> */  } } } } } } } } }
+  /* close each nested if ===> */  } } } } } } } }
   assert(call->in(call->req()-1) != NULL, "must initialize all parms");
 
   if (!is_leaf) {

--- a/src/hotspot/share/opto/graphKit.hpp
+++ b/src/hotspot/share/opto/graphKit.hpp
@@ -802,8 +802,7 @@ class GraphKit : public Phase {
                           Node* parm0 = NULL, Node* parm1 = NULL,
                           Node* parm2 = NULL, Node* parm3 = NULL,
                           Node* parm4 = NULL, Node* parm5 = NULL,
-                          Node* parm6 = NULL, Node* parm7 = NULL,
-                          Node* parm8 = NULL);
+                          Node* parm6 = NULL, Node* parm7 = NULL);
 
   Node* sign_extend_byte(Node* in);
   Node* sign_extend_short(Node* in);

--- a/src/hotspot/share/opto/library_call.cpp
+++ b/src/hotspot/share/opto/library_call.cpp
@@ -6763,70 +6763,69 @@ bool LibraryCallKit::inline_galoisCounterMode_AESCrypt() {
   Node* gctr_object = argument(7);
   Node* ghash_object = argument(8);
 
-    // (1) in, ct and out are arrays.
-    const Type* in_type = in->Value(&_gvn);
-    const Type* ct_type = ct->Value(&_gvn);
-    const Type* out_type = out->Value(&_gvn);
-    const TypeAryPtr* top_in = in_type->isa_aryptr();
-    const TypeAryPtr* top_ct = ct_type->isa_aryptr();
-    const TypeAryPtr* top_out = out_type->isa_aryptr();
-    assert(top_in != NULL && top_in->klass() != NULL &&
-           top_ct != NULL && top_ct->klass() != NULL &&
-           top_out != NULL && top_out->klass() != NULL, "args are strange");
+  // (1) in, ct and out are arrays.
+  const Type* in_type = in->Value(&_gvn);
+  const Type* ct_type = ct->Value(&_gvn);
+  const Type* out_type = out->Value(&_gvn);
+  const TypeAryPtr* top_in = in_type->isa_aryptr();
+  const TypeAryPtr* top_ct = ct_type->isa_aryptr();
+  const TypeAryPtr* top_out = out_type->isa_aryptr();
+  assert(top_in != NULL && top_in->klass() != NULL &&
+         top_ct != NULL && top_ct->klass() != NULL &&
+         top_out != NULL && top_out->klass() != NULL, "args are strange");
 
-    // checks are the responsibility of the caller
-    Node* in_start = in;
-    Node* ct_start = ct;
-    Node* out_start = out;
-    if (inOfs != NULL || ctOfs != NULL || outOfs != NULL) {
-      assert(inOfs != NULL && ctOfs != NULL && outOfs != NULL, "");
-      in_start = array_element_address(in, inOfs, T_BYTE);
-      ct_start = array_element_address(ct, ctOfs, T_BYTE);
-      out_start = array_element_address(out, outOfs, T_BYTE);
-    }
+  // checks are the responsibility of the caller
+  Node* in_start = in;
+  Node* ct_start = ct;
+  Node* out_start = out;
+  if (inOfs != NULL || ctOfs != NULL || outOfs != NULL) {
+    assert(inOfs != NULL && ctOfs != NULL && outOfs != NULL, "");
+    in_start = array_element_address(in, inOfs, T_BYTE);
+    ct_start = array_element_address(ct, ctOfs, T_BYTE);
+    out_start = array_element_address(out, outOfs, T_BYTE);
+  }
 
-    // if we are in this set of code, we "know" the embeddedCipher is an AESCrypt object
-    // (because of the predicated logic executed earlier).
-    // so we cast it here safely.
-    // this requires a newer class file that has this array as littleEndian ints, otherwise we revert to java
-    Node* embeddedCipherObj = load_field_from_object(gctr_object, "embeddedCipher", "Lcom/sun/crypto/provider/SymmetricCipher;");
-    Node* counter = load_field_from_object(gctr_object, "counter", "[B");
-    Node* subkeyHtbl = load_field_from_object(ghash_object, "subkeyHtbl", "[J");
-    Node* state = load_field_from_object(ghash_object, "state", "[J");
+  // if we are in this set of code, we "know" the embeddedCipher is an AESCrypt object
+  // (because of the predicated logic executed earlier).
+  // so we cast it here safely.
+  // this requires a newer class file that has this array as littleEndian ints, otherwise we revert to java
+  Node* embeddedCipherObj = load_field_from_object(gctr_object, "embeddedCipher", "Lcom/sun/crypto/provider/SymmetricCipher;");
+  Node* counter = load_field_from_object(gctr_object, "counter", "[B");
+  Node* subkeyHtbl = load_field_from_object(ghash_object, "subkeyHtbl", "[J");
+  Node* state = load_field_from_object(ghash_object, "state", "[J");
 
-    if (embeddedCipherObj == NULL || counter == NULL || subkeyHtbl == NULL || state == NULL) {
-        return false;
-    }
-    // cast it to what we know it will be at runtime
-    const TypeInstPtr* tinst = _gvn.type(gctr_object)->isa_instptr();
-    assert(tinst != NULL, "GCTR obj is null");
-    assert(tinst->klass()->is_loaded(), "GCTR obj is not loaded");
-    ciKlass* klass_AESCrypt = tinst->klass()->as_instance_klass()->find_klass(ciSymbol::make("com/sun/crypto/provider/AESCrypt"));
-    assert(klass_AESCrypt->is_loaded(), "predicate checks that this class is loaded");
-    ciInstanceKlass* instklass_AESCrypt = klass_AESCrypt->as_instance_klass();
-    const TypeKlassPtr* aklass = TypeKlassPtr::make(instklass_AESCrypt);
-    const TypeOopPtr* xtype = aklass->as_instance_type();
-    Node* aescrypt_object = new CheckCastPPNode(control(), embeddedCipherObj, xtype);
-    aescrypt_object = _gvn.transform(aescrypt_object);
-    // we need to get the start of the aescrypt_object's expanded key array
-    Node* k_start = get_key_start_from_aescrypt_object(aescrypt_object);
-    if (k_start == NULL) return false;
+  if (embeddedCipherObj == NULL || counter == NULL || subkeyHtbl == NULL || state == NULL) {
+    return false;
+  }
+  // cast it to what we know it will be at runtime
+  const TypeInstPtr* tinst = _gvn.type(gctr_object)->isa_instptr();
+  assert(tinst != NULL, "GCTR obj is null");
+  assert(tinst->klass()->is_loaded(), "GCTR obj is not loaded");
+  ciKlass* klass_AESCrypt = tinst->klass()->as_instance_klass()->find_klass(ciSymbol::make("com/sun/crypto/provider/AESCrypt"));
+  assert(klass_AESCrypt->is_loaded(), "predicate checks that this class is loaded");
+  ciInstanceKlass* instklass_AESCrypt = klass_AESCrypt->as_instance_klass();
+  const TypeKlassPtr* aklass = TypeKlassPtr::make(instklass_AESCrypt);
+  const TypeOopPtr* xtype = aklass->as_instance_type();
+  Node* aescrypt_object = new CheckCastPPNode(control(), embeddedCipherObj, xtype);
+  aescrypt_object = _gvn.transform(aescrypt_object);
+  // we need to get the start of the aescrypt_object's expanded key array
+  Node* k_start = get_key_start_from_aescrypt_object(aescrypt_object);
+  if (k_start == NULL) return false;
+  // similarly, get the start address of the r vector
+  Node* cnt_start = array_element_address(counter, intcon(0), T_BYTE);
+  Node* state_start = array_element_address(state, intcon(0), T_LONG);
+  Node* subkeyHtbl_start = array_element_address(subkeyHtbl, intcon(0), T_LONG);
 
-    // similarly, get the start address of the r vector
-    Node* cnt_start = array_element_address(counter, intcon(0), T_BYTE);
-    Node* state_start = array_element_address(state, intcon(0), T_LONG);
-    Node* subkeyHtbl_start = array_element_address(subkeyHtbl, intcon(0), T_LONG);
 
+  // Call the stub, passing params
+  Node* gcmCrypt = make_runtime_call(RC_LEAF|RC_NO_FP,
+                               OptoRuntime::galoisCounterMode_aescrypt_Type(),
+                               stubAddr, stubName, TypePtr::BOTTOM,
+                               in_start, len, ct_start, out_start, k_start, state_start, subkeyHtbl_start, cnt_start);
 
-    // Call the stub, passing params
-    Node* gcmCrypt = make_runtime_call(RC_LEAF|RC_NO_FP,
-                                 OptoRuntime::galoisCounterMode_aescrypt_Type(),
-                                 stubAddr, stubName, TypePtr::BOTTOM,
-                                 in_start, len, ct_start, out_start, k_start, state_start, subkeyHtbl_start, cnt_start);
-
-    // return cipher length (int)
-    Node* retvalue = _gvn.transform(new ProjNode(gcmCrypt, TypeFunc::Parms));
-    set_result(retvalue);
+  // return cipher length (int)
+  Node* retvalue = _gvn.transform(new ProjNode(gcmCrypt, TypeFunc::Parms));
+  set_result(retvalue);
 
   return true;
 }

--- a/src/hotspot/share/opto/runtime.cpp
+++ b/src/hotspot/share/opto/runtime.cpp
@@ -958,7 +958,7 @@ const TypeFunc* OptoRuntime::counterMode_aescrypt_Type() {
 //for counterMode calls of aescrypt encrypt/decrypt, four pointers and a length, returning int
 const TypeFunc* OptoRuntime::galoisCounterMode_aescrypt_Type() {
   // create input type (domain)
-  int num_args = 9;
+  int num_args = 8;
   int argcnt = num_args;
   const Type** fields = TypeTuple::fields(argcnt);
   int argp = TypeFunc::Parms;
@@ -969,7 +969,6 @@ const TypeFunc* OptoRuntime::galoisCounterMode_aescrypt_Type() {
   fields[argp++] = TypePtr::NOTNULL; // byte[] key from AESCrypt obj
   fields[argp++] = TypePtr::NOTNULL; // long[] state from GHASH obj
   fields[argp++] = TypePtr::NOTNULL; // long[] subkeyHtbl from GHASH obj
-  fields[argp++] = TypePtr::NOTNULL; // long[] avx512_subkeyHtbl newly created
   fields[argp++] = TypePtr::NOTNULL; // byte[] counter from GCTR obj
 
   assert(argp == TypeFunc::Parms + argcnt, "correct decoding");

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -37,4 +37,3 @@ vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 82456
 
 serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 
-compiler/codegen/aes/TestAESMain.java 8274323 linux-x64,windows-x64


### PR DESCRIPTION
The failure happens with XX:+DeoptimizeAlot option. I've set reexecute bit and reset the appropriate state for the interpreter to execute the code when deoptimization occurs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274323](https://bugs.openjdk.java.net/browse/JDK-8274323): compiler/codegen/aes/TestAESMain.java failed with "Error: invalid offset: -1434443640" after 8273297


### Reviewers
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/19.diff">https://git.openjdk.java.net/jdk18/pull/19.diff</a>

</details>
