### PR TITLE
8274007: [REDO] VM Exit does not abort concurrent mark

### DIFF
--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.cpp
@@ -2028,9 +2028,8 @@ void G1ConcurrentMark::concurrent_cycle_abort() {
   for (uint i = 0; i < _max_num_tasks; ++i) {
     _tasks[i]->clear_region_fields();
   }
-  _first_overflow_barrier_sync.abort();
-  _second_overflow_barrier_sync.abort();
-  _has_aborted = true;
+
+  abort_marking_threads();
 
   SATBMarkQueueSet& satb_mq_set = G1BarrierSet::satb_mark_queue_set();
   satb_mq_set.abandon_partial_marking();
@@ -2039,6 +2038,12 @@ void G1ConcurrentMark::concurrent_cycle_abort() {
   satb_mq_set.set_active_all_threads(
                                  false, /* new active value */
                                  satb_mq_set.is_active() /* expected_active */);
+}
+
+void G1ConcurrentMark::abort_marking_threads() {
+  _has_aborted = true;
+  _first_overflow_barrier_sync.abort();
+  _second_overflow_barrier_sync.abort();
 }
 
 static void print_ms_time_info(const char* prefix, const char* name,

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -497,7 +497,8 @@ public:
   void concurrent_cycle_end();
 
   // Notifies marking threads to abort. This is a best-effort notification. Does not
-  // guarantee or update any state after the call.
+  // guarantee or update any state after the call. Root region scan must not be
+  // running.
   void abort_marking_threads();
 
   void update_accum_task_vtime(int i, double vtime) {

--- a/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMark.hpp
@@ -496,6 +496,10 @@ public:
   void concurrent_cycle_abort();
   void concurrent_cycle_end();
 
+  // Notifies marking threads to abort. This is a best-effort notification. Does not
+  // guarantee or update any state after the call.
+  void abort_marking_threads();
+
   void update_accum_task_vtime(int i, double vtime) {
     _accum_task_vtime[i] += vtime;
   }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -159,6 +159,8 @@ void G1ConcurrentMarkThread::run_service() {
 }
 
 void G1ConcurrentMarkThread::stop_service() {
+  _cm->abort_marking_threads();
+
   MutexLocker ml(CGC_lock, Mutex::_no_safepoint_check_flag);
   CGC_lock->notify_all();
 }

--- a/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
+++ b/src/hotspot/share/gc/g1/g1ConcurrentMarkThread.cpp
@@ -159,7 +159,14 @@ void G1ConcurrentMarkThread::run_service() {
 }
 
 void G1ConcurrentMarkThread::stop_service() {
-  _cm->abort_marking_threads();
+  if (in_progress()) {
+    // We are not allowed to abort the marking threads during root region scan.
+    // Needs to be done separately.
+    _cm->root_regions()->abort();
+    _cm->root_regions()->wait_until_scan_finished();
+
+    _cm->abort_marking_threads();
+  }
 
   MutexLocker ml(CGC_lock, Mutex::_no_safepoint_check_flag);
   CGC_lock->notify_all();


### PR DESCRIPTION
Hi all,

  can I get reviews for this change that redos JDK-8273605 that implemented faster abort of concurrent marking when the VM is about to shutdown?

In the earlier change (first commit in this change) had the following issues:
  * it tried to abort (set the abort flag) marking even when root region scanning was active; this is something G1 does not support. In this change we cancel and wait for completion of that phase instead.
  * the second problem has been in `G1ConcurrentMark::concurrent_cycle_abort`: if a full gc were triggered during VM shutdown, the next bitmap would not be cleared. I.e. the condition to skip the rest of the mark abort handling (in `concurrent_cycle_abort`) in the full gc pause has been wrong.
 The first part `!cm_thread()->in_progress()` is correct, but the `|| _has_aborted` part is bad: aborting the marking (as in aborting during shutdown, what this change wants to achieve) does not clear the (next) mark bitmap at all with that condition. This is actually a long standing issue: however since nobody aborted the marking early except full gc (where we are in the moment), this path has never been taken, so afaict no harm done. (Global mark stack overflow causes abort of the *mark task*, and overflow of the *mark state*). Another issue with using `_has_aborted` here is that `_has_aborted` might have already been cleared when the full gc occurs: i.e. we abort the marking, it finishes its marking cycle (clearing `_has_aborted`) and only then that full gc happens.
The correct way is to keep on clearing the next bitmap (for the full gc(s)) if we aborted the marking due to shutdown (`_g1h->concurrent_mark_is_terminating()`).
This has the disadvantage that not only the first full gc during shutdown clears the next bitmap, but also any subsequent full gcs (concurrent marking is already prohibited to start during shutdown), and they do that unnecessarily.
However any change here (like keeping a flag whether the next bitmap is dirty) seemed to be an unnecessary complication unsuitable for such a change, and any full gc will be much longer than clearing the bitmap once anyway).
Another alternative that has been considered has been making an explicit shutdown state in `G1ConcurrentMarkThread`; however that would mirror functionality provided in `ConcurrentGCThread`, which does not improve the code, or at least at this time I would prefer not to change something there.
 
Testing: hs-tier1-5,  vmTestbase/vm/mlvm/meth/stress/gc/callSequencesDuringGC/Test.java a few thousand times without issue (both on jdk18 and jdk19)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8274007](https://bugs.openjdk.java.net/browse/JDK-8274007): [REDO] VM Exit does not abort concurrent mark


### Reviewers
 * [Stefan Johansson](https://openjdk.java.net/census#sjohanss) (@kstefanj - **Reviewer**) ⚠️ Review applies to 8a10c76c19b96ec2f6a3e07b455d1e568f41d5ef
 * [Ivan Walulya](https://openjdk.java.net/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/22.diff">https://git.openjdk.java.net/jdk18/pull/22.diff</a>

</details>
