### PR TITLE
8278744: KeyStore:getAttributes() not returning unmodifiable Set

### DIFF
--- a/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
+++ b/src/java.base/share/classes/sun/security/pkcs12/PKCS12KeyStore.java
@@ -1313,7 +1313,7 @@ public final class PKCS12KeyStore extends KeyStoreSpi {
             return super.engineGetAttributes(alias);
         }
         Entry entry = entries.get(alias.toLowerCase(Locale.ENGLISH));
-        return getAttributes(entry);
+        return Collections.unmodifiableSet(new HashSet<>(getAttributes(entry)));
     }
 
     /**

--- a/test/jdk/java/security/KeyStore/PKCS12/UnmodifiableAttributes.java
+++ b/test/jdk/java/security/KeyStore/PKCS12/UnmodifiableAttributes.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8278744
+ * @summary KeyStore:getAttributes() not returning unmodifiable Set
+ * @library /test/lib
+ */
+
+import jdk.test.lib.SecurityTools;
+import jdk.test.lib.Utils;
+
+import java.io.File;
+import java.security.KeyStore;
+
+public class UnmodifiableAttributes {
+    public static final void main(String[] args) throws Exception {
+
+        var oneAttr = new KeyStore.Entry.Attribute() {
+            @Override
+            public String getName() {
+                return "1.2.3";
+            }
+
+            @Override
+            public String getValue() {
+                return "testVal";
+            }
+        };
+        char[] pass = "changeit".toCharArray();
+
+        SecurityTools.keytool("-keystore ks -storepass changeit -genkeypair -alias a -dname CN=A -keyalg EC")
+                .shouldHaveExitValue(0);
+
+        KeyStore ks = KeyStore.getInstance(new File("ks"), pass);
+
+        var attrs = ks.getAttributes("a");
+        Utils.runAndCheckException(() -> attrs.add(oneAttr), UnsupportedOperationException.class);
+
+        var attrs2 = ks.getEntry("a", new KeyStore.PasswordProtection(pass)).getAttributes();
+        Utils.runAndCheckException(() -> attrs2.add(oneAttr), UnsupportedOperationException.class);
+    }
+}


### PR DESCRIPTION
Make the return value of `PKCS12KeyStore::engineGetAttributes` immutable. Gather the `getAttributes()` value into a new `HashSet` and then make it immutable. This ensures the final result itself is not mutable and it also will not change even if the internal `entry.attributes` is modified.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278744](https://bugs.openjdk.java.net/browse/JDK-8278744): KeyStore:getAttributes() not returning unmodifiable Set


### Reviewers
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/23.diff">https://git.openjdk.java.net/jdk18/pull/23.diff</a>

</details>
