### PR TITLE
8278508: Enable X86 maskAll instruction pattern for 32 bit JVM.

### DIFF
--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -2796,6 +2796,7 @@ void Assembler::kshiftlql(KRegister dst, KRegister src, int imm8) {
   emit_int8(imm8);
 }
 
+
 void Assembler::kshiftrbl(KRegister dst, KRegister src, int imm8) {
   assert(VM_Version::supports_avx512dq(), "");
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
@@ -2825,6 +2826,13 @@ void Assembler::kshiftrql(KRegister dst, KRegister src, int imm8) {
   int encode = vex_prefix_and_encode(dst->encoding(), 0 , src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
   emit_int16(0x31, (0xC0 | encode));
   emit_int8(imm8);
+}
+
+void Assembler::kunpckdql(KRegister dst, KRegister src1, KRegister src2) {
+  assert(VM_Version::supports_avx512bw(), "");
+  InstructionAttr attributes(AVX_256bit, /* rex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
+  int encode = vex_prefix_and_encode(dst->encoding(), src1->encoding(), src2->encoding(), VEX_SIMD_NONE, VEX_OPCODE_0F, &attributes);
+  emit_int16(0x4B, (0xC0 | encode));
 }
 
 void Assembler::movb(Address dst, int imm8) {

--- a/src/hotspot/cpu/x86/assembler_x86.cpp
+++ b/src/hotspot/cpu/x86/assembler_x86.cpp
@@ -2788,6 +2788,14 @@ void Assembler::kshiftlbl(KRegister dst, KRegister src, int imm8) {
   emit_int8(imm8);
 }
 
+void Assembler::kshiftlql(KRegister dst, KRegister src, int imm8) {
+  assert(VM_Version::supports_avx512bw(), "");
+  InstructionAttr attributes(AVX_128bit, /* rex_w */ true, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);
+  int encode = vex_prefix_and_encode(dst->encoding(), 0 , src->encoding(), VEX_SIMD_66, VEX_OPCODE_0F_3A, &attributes);
+  emit_int16(0x33, (0xC0 | encode));
+  emit_int8(imm8);
+}
+
 void Assembler::kshiftrbl(KRegister dst, KRegister src, int imm8) {
   assert(VM_Version::supports_avx512dq(), "");
   InstructionAttr attributes(AVX_128bit, /* rex_w */ false, /* legacy_mode */ true, /* no_mask_reg */ true, /* uses_vl */ false);

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1517,6 +1517,8 @@ private:
   void kshiftrql(KRegister dst, KRegister src, int imm8);
   void ktestq(KRegister src1, KRegister src2);
   void ktestd(KRegister src1, KRegister src2);
+  void kunpckdql(KRegister dst, KRegister src1, KRegister src2);
+
 
   void ktestql(KRegister dst, KRegister src);
   void ktestdl(KRegister dst, KRegister src);

--- a/src/hotspot/cpu/x86/assembler_x86.hpp
+++ b/src/hotspot/cpu/x86/assembler_x86.hpp
@@ -1510,6 +1510,7 @@ private:
 
   void kxnorbl(KRegister dst, KRegister src1, KRegister src2);
   void kshiftlbl(KRegister dst, KRegister src, int imm8);
+  void kshiftlql(KRegister dst, KRegister src, int imm8);
   void kshiftrbl(KRegister dst, KRegister src, int imm8);
   void kshiftrwl(KRegister dst, KRegister src, int imm8);
   void kshiftrdl(KRegister dst, KRegister src, int imm8);

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4278,9 +4278,6 @@ void C2_MacroAssembler::vector_maskall_operation(KRegister dst, Register src, in
   if (VM_Version::supports_avx512bw()) {
     if (mask_len > 32) {
       kmovql(dst, src);
-      if (mask_len != 64) {
-        kshiftrql(dst, dst, 64 - mask_len);
-      }
     } else {
       kmovdl(dst, src);
       if (mask_len != 32) {
@@ -4301,6 +4298,5 @@ void C2_MacroAssembler::vector_maskall_operation32(KRegister dst, Register src, 
   assert(VM_Version::supports_avx512bw(), "");
   kmovdl(tmp, src);
   kunpckdql(dst, tmp, tmp);
-  kshiftrql(dst, dst, 64 - mask_len);
 }
 #endif

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4278,15 +4278,21 @@ void C2_MacroAssembler::vector_maskall_operation(KRegister dst, Register src, in
   if (VM_Version::supports_avx512bw()) {
     if (mask_len > 32) {
       kmovql(dst, src);
-      kshiftrql(dst, dst, 64 - mask_len);
+      if (mask_len != 64) {
+        kshiftrql(dst, dst, 64 - mask_len);
+      }
     } else {
       kmovdl(dst, src);
-      kshiftrdl(dst, dst, 32 - mask_len);
+      if (mask_len != 32) {
+        kshiftrdl(dst, dst, 32 - mask_len);
+      }
     }
   } else {
     assert(mask_len <= 16, "");
     kmovwl(dst, src);
-    kshiftrwl(dst, dst, 16 - mask_len);
+    if (mask_len != 16) {
+      kshiftrwl(dst, dst, 16 - mask_len);
+    }
   }
 }
 
@@ -4294,8 +4300,7 @@ void C2_MacroAssembler::vector_maskall_operation(KRegister dst, Register src, in
 void C2_MacroAssembler::vector_maskall_operation32(KRegister dst, Register src, KRegister tmp, int mask_len) {
   assert(VM_Version::supports_avx512bw(), "");
   kmovdl(tmp, src);
-  kshiftlql(dst, tmp, 32);
-  korql(dst, dst, tmp);
+  kunpckdql(dst, tmp, tmp);
   kshiftrql(dst, dst, 64 - mask_len);
 }
 #endif

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4273,3 +4273,29 @@ void C2_MacroAssembler::vector_mask_operation(int opc, Register dst, XMMRegister
   vector_mask_operation_helper(opc, dst, tmp, masklen);
 }
 #endif
+
+void C2_MacroAssembler::vector_maskall_operation(KRegister dst, Register src, int mask_len) {
+  if (VM_Version::supports_avx512bw()) {
+    if (mask_len > 32) {
+      kmovql(dst, src);
+      kshiftrql(dst, dst, 64 - mask_len);
+    } else {
+      kmovdl(dst, src);
+      kshiftrdl(dst, dst, 32 - mask_len);
+    }
+  } else {
+    assert(mask_len <= 16, "");
+    kmovwl(dst, src);
+    kshiftrwl(dst, dst, 16 - mask_len);
+  }
+}
+
+#ifndef _LP64
+void C2_MacroAssembler::vector_maskall_operation32(KRegister dst, Register src, KRegister tmp, int mask_len) {
+  assert(VM_Version::supports_avx512bw(), "");
+  kmovdl(tmp, src);
+  kshiftlql(dst, tmp, 32);
+  korql(dst, dst, tmp);
+  kshiftrql(dst, dst, 64 - mask_len);
+}
+#endif

--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.hpp
@@ -231,6 +231,13 @@ public:
   void vector_mask_operation(int opc, Register dst, XMMRegister mask, XMMRegister xtmp,
                              Register tmp, int masklen, BasicType bt, int vec_enc);
 #endif
+
+  void vector_maskall_operation(KRegister dst, Register src, int mask_len);
+
+#ifndef _LP64
+  void vector_maskall_operation32(KRegister dst, Register src, KRegister ktmp, int mask_len);
+#endif
+
   void string_indexof_char(Register str1, Register cnt1, Register ch, Register result,
                            XMMRegister vec1, XMMRegister vec2, XMMRegister vec3, Register tmp);
 

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -9451,19 +9451,6 @@ instruct evcmp_masked(kReg dst, vec src1, vec src2, immI8 cond, kReg mask, rRegP
   ins_pipe( pipe_slow );
 %}
 
-instruct mask_all_evexI_imm_LE32(kReg dst, immI cnt, rRegI tmp) %{
-  predicate(Matcher::vector_length(n) <= 32);
-  match(Set dst (MaskAll cnt));
-  effect(TEMP dst, TEMP tmp);
-  format %{ "mask_all_evexI_imm_LE32 $dst, $cnt \t! using $tmp as TEMP" %}
-  ins_encode %{
-    int mask_len = Matcher::vector_length(this);
-    __ movl($tmp$$Register, $cnt$$constant);
-    __ vector_maskall_operation($dst$$KRegister, $tmp$$Register, mask_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
 instruct mask_all_evexI_LE32(kReg dst, rRegI src) %{
   predicate(Matcher::vector_length(n) <= 32);
   match(Set dst (MaskAll src));

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -9454,7 +9454,6 @@ instruct evcmp_masked(kReg dst, vec src1, vec src2, immI8 cond, kReg mask, rRegP
 instruct mask_all_evexI_LE32(kReg dst, rRegI src) %{
   predicate(Matcher::vector_length(n) <= 32);
   match(Set dst (MaskAll src));
-  effect(TEMP dst);
   format %{ "mask_all_evexI_LE32 $dst, $src \t" %}
   ins_encode %{
     int mask_len = Matcher::vector_length(this);

--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1827,7 +1827,7 @@ const bool Matcher::match_rule_supported_vector(int opcode, int vlen, BasicType 
       }
       break;
     case Op_MaskAll:
-      if (!is_LP64 || !VM_Version::supports_evex()) {
+      if (!VM_Version::supports_evex()) {
         return false;
       }
       if ((vlen > 16 || is_subword_type(bt)) && !VM_Version::supports_avx512bw()) {
@@ -9451,64 +9451,32 @@ instruct evcmp_masked(kReg dst, vec src1, vec src2, immI8 cond, kReg mask, rRegP
   ins_pipe( pipe_slow );
 %}
 
-#ifdef _LP64
-instruct mask_all_evexI_imm(kReg dst, immI cnt, rRegL tmp) %{
+instruct mask_all_evexI_imm_LE32(kReg dst, immI cnt, rRegI tmp) %{
+  predicate(Matcher::vector_length(n) <= 32);
   match(Set dst (MaskAll cnt));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "mask_all_evexI $dst, $cnt \t! using $tmp as TEMP" %}
+  effect(TEMP dst, TEMP tmp);
+  format %{ "mask_all_evexI_imm_LE32 $dst, $cnt \t! using $tmp as TEMP" %}
   ins_encode %{
-    int vec_len = Matcher::vector_length(this);
-    if (VM_Version::supports_avx512bw()) {
-      __ movq($tmp$$Register, $cnt$$constant);
-      __ kmovql($dst$$KRegister, $tmp$$Register);
-      __ kshiftrql($dst$$KRegister, $dst$$KRegister, 64 - vec_len);
-    } else {
-      assert(vec_len <= 16, "");
-      __ movq($tmp$$Register, $cnt$$constant);
-      __ kmovwl($dst$$KRegister, $tmp$$Register);
-      __ kshiftrwl($dst$$KRegister, $dst$$KRegister, 16 - vec_len);
-    }
+    int mask_len = Matcher::vector_length(this);
+    __ movl($tmp$$Register, $cnt$$constant);
+    __ vector_maskall_operation($dst$$KRegister, $tmp$$Register, mask_len);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct mask_all_evexI(kReg dst, rRegI src, rRegL tmp) %{
+instruct mask_all_evexI_LE32(kReg dst, rRegI src) %{
+  predicate(Matcher::vector_length(n) <= 32);
   match(Set dst (MaskAll src));
-  effect(TEMP_DEF dst, TEMP tmp);
-  format %{ "mask_all_evexI $dst, $src \t! using $tmp as TEMP" %}
+  effect(TEMP dst);
+  format %{ "mask_all_evexI_LE32 $dst, $src \t" %}
   ins_encode %{
-    int vec_len = Matcher::vector_length(this);
-    if (VM_Version::supports_avx512bw()) {
-      __ movslq($tmp$$Register, $src$$Register);
-      __ kmovql($dst$$KRegister, $tmp$$Register);
-      __ kshiftrql($dst$$KRegister, $dst$$KRegister, 64 - vec_len);
-    } else {
-      assert(vec_len <= 16, "");
-      __ kmovwl($dst$$KRegister, $src$$Register);
-      __ kshiftrwl($dst$$KRegister, $dst$$KRegister, 16 - vec_len);
-    }
+    int mask_len = Matcher::vector_length(this);
+    __ vector_maskall_operation($dst$$KRegister, $src$$Register, mask_len);
   %}
   ins_pipe( pipe_slow );
 %}
 
-instruct mask_all_evexL(kReg dst, rRegL src) %{
-  match(Set dst (MaskAll src));
-  effect(TEMP_DEF dst);
-  format %{ "mask_all_evexL $dst, $src \t! mask all operation" %}
-  ins_encode %{
-    int vec_len = Matcher::vector_length(this);
-    if (VM_Version::supports_avx512bw()) {
-      __ kmovql($dst$$KRegister, $src$$Register);
-      __ kshiftrql($dst$$KRegister, $dst$$KRegister, 64 - vec_len);
-    } else {
-      assert(vec_len <= 16, "");
-      __ kmovwl($dst$$KRegister, $src$$Register);
-      __ kshiftrwl($dst$$KRegister, $dst$$KRegister, 16 - vec_len);
-    }
-  %}
-  ins_pipe( pipe_slow );
-%}
-
+#ifdef _LP64
 instruct mask_not_immLT8(kReg dst, kReg src, rRegI rtmp, kReg ktmp, immI_M1 cnt) %{
   predicate(Matcher::vector_length(n) < 8 && VM_Version::supports_avx512dq());
   match(Set dst (XorVMask src (MaskAll cnt)));

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -13883,19 +13883,6 @@ instruct mask_all_evexI_GT32(kReg dst, rRegI src, kReg ktmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct mask_all_evexI_imm_GT32(kReg dst, immI cnt, rRegI tmp, kReg ktmp) %{
-  predicate(Matcher::vector_length(n) > 32);
-  match(Set dst (MaskAll cnt));
-  effect(TEMP dst, TEMP tmp, TEMP ktmp);
-  format %{ "mask_all_evex_imm_GT32 $dst, $cnt \t! using $tmp and $ktmp as TEMP" %}
-  ins_encode %{
-    int mask_len = Matcher::vector_length(this);
-    __ movl($tmp$$Register, $cnt$$constant);
-    __ vector_maskall_operation32($dst$$KRegister, $tmp$$Register, $ktmp$$KRegister, mask_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
 // ============================================================================
 // Safepoint Instruction
 instruct safePoint_poll_tls(eFlagsReg cr, eRegP_no_EBP poll) %{

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -13847,7 +13847,54 @@ instruct cmpFastUnlock(eFlagsReg cr, eRegP object, eAXRegP box, eRegP tmp ) %{
   ins_pipe(pipe_slow);
 %}
 
+instruct mask_all_evexL_LT32(kReg dst, eRegL src) %{
+  predicate(Matcher::vector_length(n) <= 32);
+  match(Set dst (MaskAll src));
+  effect(TEMP dst);
+  format %{ "mask_all_evexL_LE32 $dst, $src \t" %}
+  ins_encode %{
+    int mask_len = Matcher::vector_length(this);
+    __ vector_maskall_operation($dst$$KRegister, $src$$Register, mask_len);
+  %}
+  ins_pipe( pipe_slow );
+%}
 
+instruct mask_all_evexL_GT32(kReg dst, eRegL src, kReg ktmp) %{
+  predicate(Matcher::vector_length(n) > 32);
+  match(Set dst (MaskAll src));
+  effect(TEMP dst, TEMP ktmp);
+  format %{ "mask_all_evexL_GT32 $dst, $src \t! using $ktmp as TEMP " %}
+  ins_encode %{
+    int mask_len = Matcher::vector_length(this);
+    __ vector_maskall_operation32($dst$$KRegister, $src$$Register, $ktmp$$KRegister, mask_len);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct mask_all_evexI_GT32(kReg dst, rRegI src, kReg ktmp) %{
+  predicate(Matcher::vector_length(n) > 32);
+  match(Set dst (MaskAll src));
+  effect(TEMP dst, TEMP ktmp);
+  format %{ "mask_all_evexI_GT32 $dst, $src \t! using $ktmp as TEMP" %}
+  ins_encode %{
+    int mask_len = Matcher::vector_length(this);
+    __ vector_maskall_operation32($dst$$KRegister, $src$$Register, $ktmp$$KRegister, mask_len);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct mask_all_evexI_imm_GT32(kReg dst, immI cnt, rRegI tmp, kReg ktmp) %{
+  predicate(Matcher::vector_length(n) > 32);
+  match(Set dst (MaskAll cnt));
+  effect(TEMP dst, TEMP tmp, TEMP ktmp);
+  format %{ "mask_all_evex_imm_GT32 $dst, $cnt \t! using $tmp and $ktmp as TEMP" %}
+  ins_encode %{
+    int mask_len = Matcher::vector_length(this);
+    __ movl($tmp$$Register, $cnt$$constant);
+    __ vector_maskall_operation32($dst$$KRegister, $tmp$$Register, $ktmp$$KRegister, mask_len);
+  %}
+  ins_pipe( pipe_slow );
+%}
 
 // ============================================================================
 // Safepoint Instruction

--- a/src/hotspot/cpu/x86/x86_32.ad
+++ b/src/hotspot/cpu/x86/x86_32.ad
@@ -13850,7 +13850,6 @@ instruct cmpFastUnlock(eFlagsReg cr, eRegP object, eAXRegP box, eRegP tmp ) %{
 instruct mask_all_evexL_LT32(kReg dst, eRegL src) %{
   predicate(Matcher::vector_length(n) <= 32);
   match(Set dst (MaskAll src));
-  effect(TEMP dst);
   format %{ "mask_all_evexL_LE32 $dst, $src \t" %}
   ins_encode %{
     int mask_len = Matcher::vector_length(this);
@@ -13862,7 +13861,7 @@ instruct mask_all_evexL_LT32(kReg dst, eRegL src) %{
 instruct mask_all_evexL_GT32(kReg dst, eRegL src, kReg ktmp) %{
   predicate(Matcher::vector_length(n) > 32);
   match(Set dst (MaskAll src));
-  effect(TEMP dst, TEMP ktmp);
+  effect(TEMP ktmp);
   format %{ "mask_all_evexL_GT32 $dst, $src \t! using $ktmp as TEMP " %}
   ins_encode %{
     int mask_len = Matcher::vector_length(this);
@@ -13874,7 +13873,7 @@ instruct mask_all_evexL_GT32(kReg dst, eRegL src, kReg ktmp) %{
 instruct mask_all_evexI_GT32(kReg dst, rRegI src, kReg ktmp) %{
   predicate(Matcher::vector_length(n) > 32);
   match(Set dst (MaskAll src));
-  effect(TEMP dst, TEMP ktmp);
+  effect(TEMP ktmp);
   format %{ "mask_all_evexI_GT32 $dst, $src \t! using $ktmp as TEMP" %}
   ins_encode %{
     int mask_len = Matcher::vector_length(this);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -13013,7 +13013,6 @@ instruct safePoint_poll_tls(rFlagsReg cr, rRegP poll)
 
 instruct mask_all_evexL(kReg dst, rRegL src) %{
   match(Set dst (MaskAll src));
-  effect(TEMP dst);
   format %{ "mask_all_evexL $dst, $src \t! mask all operation" %}
   ins_encode %{
     int mask_len = Matcher::vector_length(this);
@@ -13025,7 +13024,7 @@ instruct mask_all_evexL(kReg dst, rRegL src) %{
 instruct mask_all_evexI_GT32(kReg dst, rRegI src, rRegL tmp) %{
   predicate(Matcher::vector_length(n) > 32);
   match(Set dst (MaskAll src));
-  effect(TEMP dst, TEMP tmp);
+  effect(TEMP tmp);
   format %{ "mask_all_evexI_GT32 $dst, $src \t! using $tmp as TEMP" %}
   ins_encode %{
     int mask_len = Matcher::vector_length(this);

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -13011,6 +13011,43 @@ instruct safePoint_poll_tls(rFlagsReg cr, rRegP poll)
   ins_pipe(ialu_reg_mem);
 %}
 
+instruct mask_all_evexL(kReg dst, rRegL src) %{
+  match(Set dst (MaskAll src));
+  effect(TEMP dst);
+  format %{ "mask_all_evexL $dst, $src \t! mask all operation" %}
+  ins_encode %{
+    int mask_len = Matcher::vector_length(this);
+    __ vector_maskall_operation($dst$$KRegister, $src$$Register, mask_len);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct mask_all_evexI_GT32(kReg dst, rRegI src, rRegL tmp) %{
+  predicate(Matcher::vector_length(n) > 32);
+  match(Set dst (MaskAll src));
+  effect(TEMP dst, TEMP tmp);
+  format %{ "mask_all_evexI_GT32 $dst, $src \t! using $tmp as TEMP" %}
+  ins_encode %{
+    int mask_len = Matcher::vector_length(this);
+    __ movslq($tmp$$Register, $src$$Register);
+    __ vector_maskall_operation($dst$$KRegister, $tmp$$Register, mask_len);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
+instruct mask_all_evex_imm_GT32(kReg dst, immI cnt, rRegL tmp) %{
+  predicate(Matcher::vector_length(n) > 32);
+  match(Set dst (MaskAll cnt));
+  effect(TEMP dst, TEMP tmp);
+  format %{ "mask_all_imm_GT32 $dst, $cnt \t! using $tmp as TEMP" %}
+  ins_encode %{
+    int mask_len = Matcher::vector_length(this);
+    __ movq($tmp$$Register, $cnt$$constant);
+    __ vector_maskall_operation($dst$$KRegister, $tmp$$Register, mask_len);
+  %}
+  ins_pipe( pipe_slow );
+%}
+
 // ============================================================================
 // Procedure Call/Return Instructions
 // Call Java Static Instruction

--- a/src/hotspot/cpu/x86/x86_64.ad
+++ b/src/hotspot/cpu/x86/x86_64.ad
@@ -13035,19 +13035,6 @@ instruct mask_all_evexI_GT32(kReg dst, rRegI src, rRegL tmp) %{
   ins_pipe( pipe_slow );
 %}
 
-instruct mask_all_evex_imm_GT32(kReg dst, immI cnt, rRegL tmp) %{
-  predicate(Matcher::vector_length(n) > 32);
-  match(Set dst (MaskAll cnt));
-  effect(TEMP dst, TEMP tmp);
-  format %{ "mask_all_imm_GT32 $dst, $cnt \t! using $tmp as TEMP" %}
-  ins_encode %{
-    int mask_len = Matcher::vector_length(this);
-    __ movq($tmp$$Register, $cnt$$constant);
-    __ vector_maskall_operation($dst$$KRegister, $tmp$$Register, mask_len);
-  %}
-  ins_pipe( pipe_slow );
-%}
-
 // ============================================================================
 // Procedure Call/Return Instructions
 // Call Java Static Instruction

--- a/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
+++ b/test/jdk/jdk/incubator/vector/Byte512VectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation Byte512VectorTests
+ * @run testng/othervm/timeout=240 -ea -esa -Xbatch -XX:-TieredCompilation Byte512VectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
+++ b/test/jdk/jdk/incubator/vector/ByteMaxVectorTests.java
@@ -24,7 +24,7 @@
 /*
  * @test
  * @modules jdk.incubator.vector
- * @run testng/othervm -ea -esa -Xbatch -XX:-TieredCompilation ByteMaxVectorTests
+ * @run testng/othervm/timeout=240 -ea -esa -Xbatch -XX:-TieredCompilation ByteMaxVectorTests
  */
 
 // -- This file was mechanically generated: Do not edit! -- //

--- a/test/jdk/jdk/incubator/vector/VectorReshapeTests.java
+++ b/test/jdk/jdk/incubator/vector/VectorReshapeTests.java
@@ -39,7 +39,7 @@ import jdk.incubator.vector.VectorSpecies;
  * @test
  * @modules jdk.incubator.vector
  * @modules java.base/jdk.internal.vm.annotation
- * @run testng/othervm --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
+ * @run testng/othervm/timeout=240 --add-opens jdk.incubator.vector/jdk.incubator.vector=ALL-UNNAMED
  *      -XX:-TieredCompilation VectorReshapeTests
  */
 


### PR DESCRIPTION
- Vector.maskAll was accelerated for AVX-512 target, but  x86 existing backend implementation does not enable maskAll instruction patterns for 32 bit JVM, due to which operations fall backs over replicateB operation which broadcasts the mask value in a vector.
- In some cases after unboxing-boxing optimization this vector eventually reaches to XorVMask which has different operands one held in opmask register and other in vector.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278508](https://bugs.openjdk.java.net/browse/JDK-8278508): Enable X86 maskAll instruction pattern for 32 bit JVM.


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 4fb1ea1b1209d383384953dfcab067064fc60e7f
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/24.diff">https://git.openjdk.java.net/jdk18/pull/24.diff</a>

</details>
