### PR TITLE
8273107: RunThese24H times out with "java.lang.management.ThreadInfo.getLockName()" is null

### DIFF
--- a/src/hotspot/share/runtime/monitorDeflationThread.cpp
+++ b/src/hotspot/share/runtime/monitorDeflationThread.cpp
@@ -63,6 +63,6 @@ void MonitorDeflationThread::monitor_deflation_thread_entry(JavaThread* jt, TRAP
       }
     }
 
-    (void)ObjectSynchronizer::deflate_idle_monitors();
+    (void)ObjectSynchronizer::deflate_idle_monitors(/* ObjectMonitorsHashtable is not needed here */ nullptr);
   }
 }

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -1546,8 +1546,8 @@ size_t ObjectSynchronizer::deflate_idle_monitors(ObjectMonitorsHashtable* table)
     ls->print_cr("end deflating: in_use_list stats: ceiling=" SIZE_FORMAT ", count=" SIZE_FORMAT ", max=" SIZE_FORMAT,
                  in_use_list_ceiling(), _in_use_list.count(), _in_use_list.max());
     if (table != nullptr) {
-      ls->print_cr("ObjectMonitorsHashtable: jt_count=" SIZE_FORMAT ", om_count=" SIZE_FORMAT,
-                   table->jt_count(), table->om_count());
+      ls->print_cr("ObjectMonitorsHashtable: key_count=" SIZE_FORMAT ", om_count=" SIZE_FORMAT,
+                   table->key_count(), table->om_count());
     }
   }
 

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -190,6 +190,10 @@ class ObjectSynchronizer : AllStatic {
 
   // JNI detach support
   static void release_monitors_owned_by_thread(JavaThread* current);
+
+  // Iterate ObjectMonitors where the owner == thread; this does NOT include
+  // ObjectMonitors where owner is set to a stack lock address in thread:
+  //
   // This version of monitors_iterate() works with the in-use monitor list.
   static void monitors_iterate(MonitorClosure* m, JavaThread* thread);
   // This version of monitors_iterate() works with the specified linked list.

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -30,10 +30,67 @@
 #include "runtime/basicLock.hpp"
 #include "runtime/handles.hpp"
 #include "utilities/growableArray.hpp"
+#include "utilities/linkedlist.hpp"
+#include "utilities/resourceHash.hpp"
 
 class LogStream;
 class ObjectMonitor;
 class ThreadsList;
+
+// Hash table of JavaThread* to a list of ObjectMonitor* owned by the JavaThread*.
+//
+class ObjectMonitorsHashtable {
+ private:
+  static unsigned int ptr_hash(JavaThread* const& s1) {
+    // 2654435761 = 2^32 * Phi (golden ratio)
+    return (unsigned int)(((uint32_t)(uintptr_t)s1) * 2654435761u);
+  }
+
+ public:
+  typedef LinkedListImpl<ObjectMonitor*,
+                         ResourceObj::C_HEAP, mtThread,
+                         AllocFailStrategy::RETURN_NULL> PtrList;
+
+  // ResourceHashtable SIZE is specified at compile time so we
+  // use 1031 which is the first prime after 1024.
+  typedef ResourceHashtable<JavaThread*, PtrList*, 1031,
+                            ResourceObj::C_HEAP, mtThread,
+                            &ObjectMonitorsHashtable::ptr_hash> PtrTable;
+ private:
+  PtrTable* _ptrs;
+  size_t _jt_count;
+  size_t _om_count;
+
+ public:
+  // ResourceHashtable is passed to various functions and populated in
+  // different places so we allocate it using C_HEAP to make it immune
+  // from any ResourceMarks that happen to be in the code paths.
+  ObjectMonitorsHashtable() : _ptrs(new (ResourceObj::C_HEAP, mtThread) PtrTable()), _jt_count(0), _om_count(0) {}
+
+  ~ObjectMonitorsHashtable();
+
+  void add_entry(JavaThread* jt, ObjectMonitor* om);
+
+  void add_entry(JavaThread* jt, PtrList* list) {
+    _ptrs->put(jt, list);
+    _jt_count++;
+  }
+
+  PtrList* get_entry(JavaThread* jt) {
+    PtrList** listpp = _ptrs->get(jt);
+    return (listpp == nullptr) ? nullptr : *listpp;
+  }
+
+  bool has_entry(JavaThread* jt) {
+    PtrList** listpp = _ptrs->get(jt);
+    return listpp != nullptr && *listpp != nullptr;
+  }
+
+  bool has_entry(JavaThread* jt, ObjectMonitor* om);
+
+  size_t jt_count() { return _jt_count; }
+  size_t om_count() { return _om_count; }
+};
 
 class MonitorList {
   friend class VMStructs;
@@ -133,21 +190,26 @@ class ObjectSynchronizer : AllStatic {
 
   // JNI detach support
   static void release_monitors_owned_by_thread(JavaThread* current);
+  // This version of monitors_iterate() works with the in-use monitor list.
   static void monitors_iterate(MonitorClosure* m, JavaThread* thread);
+  // This version of monitors_iterate() works with the specified linked list.
+  static void monitors_iterate(MonitorClosure* closure,
+                               ObjectMonitorsHashtable::PtrList* list,
+                               JavaThread* thread);
 
   // Initialize the gInflationLocks
   static void initialize();
 
-  // GC: we current use aggressive monitor deflation policy
+  // GC: we currently use aggressive monitor deflation policy
   // Basically we try to deflate all monitors that are not busy.
-  static size_t deflate_idle_monitors();
+  static size_t deflate_idle_monitors(ObjectMonitorsHashtable* table);
 
   // Deflate idle monitors:
   static void chk_for_block_req(JavaThread* current, const char* op_name,
                                 const char* cnt_name, size_t cnt, LogStream* ls,
                                 elapsedTimer* timer_p);
-  static size_t deflate_monitor_list(Thread* current, LogStream* ls,
-                                     elapsedTimer* timer_p);
+  static size_t deflate_monitor_list(Thread* current, LogStream* ls, elapsedTimer* timer_p,
+                                     ObjectMonitorsHashtable* table);
   static size_t in_use_list_ceiling();
   static void dec_in_use_list_ceiling();
   static void inc_in_use_list_ceiling();

--- a/src/hotspot/share/runtime/synchronizer.hpp
+++ b/src/hotspot/share/runtime/synchronizer.hpp
@@ -59,14 +59,14 @@ class ObjectMonitorsHashtable {
                             &ObjectMonitorsHashtable::ptr_hash> PtrTable;
  private:
   PtrTable* _ptrs;
-  size_t _jt_count;
+  size_t _key_count;
   size_t _om_count;
 
  public:
   // ResourceHashtable is passed to various functions and populated in
   // different places so we allocate it using C_HEAP to make it immune
   // from any ResourceMarks that happen to be in the code paths.
-  ObjectMonitorsHashtable() : _ptrs(new (ResourceObj::C_HEAP, mtThread) PtrTable()), _jt_count(0), _om_count(0) {}
+  ObjectMonitorsHashtable() : _ptrs(new (ResourceObj::C_HEAP, mtThread) PtrTable()), _key_count(0), _om_count(0) {}
 
   ~ObjectMonitorsHashtable();
 
@@ -74,7 +74,7 @@ class ObjectMonitorsHashtable {
 
   void add_entry(void* key, PtrList* list) {
     _ptrs->put(key, list);
-    _jt_count++;
+    _key_count++;
   }
 
   PtrList* get_entry(void* key) {
@@ -89,7 +89,7 @@ class ObjectMonitorsHashtable {
 
   bool has_entry(void* key, ObjectMonitor* om);
 
-  size_t jt_count() { return _jt_count; }
+  size_t key_count() { return _key_count; }
   size_t om_count() { return _om_count; }
 };
 

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -207,7 +207,8 @@ class VM_ThreadDump : public VM_Operation {
   bool                           _with_locked_monitors;
   bool                           _with_locked_synchronizers;
 
-  void snapshot_thread(JavaThread* java_thread, ThreadConcurrentLocks* tcl);
+  void snapshot_thread(JavaThread* java_thread, ThreadConcurrentLocks* tcl,
+                       ObjectMonitorsHashtable* table);
 
  public:
   VM_ThreadDump(ThreadDumpResult* result,

--- a/src/hotspot/share/services/heapDumper.cpp
+++ b/src/hotspot/share/services/heapDumper.cpp
@@ -2388,7 +2388,7 @@ void VM_HeapDumper::dump_stack_traces() {
       HandleMark hm(current_thread);
 
       ThreadStackTrace* stack_trace = new ThreadStackTrace(thread, false);
-      stack_trace->dump_stack_at_safepoint(-1);
+      stack_trace->dump_stack_at_safepoint(-1, /* ObjectMonitorsHashtable is not needed here */ nullptr);
       _stack_traces[_num_threads++] = stack_trace;
 
       // write HPROF_FRAME records for this thread's stack trace

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -683,10 +683,12 @@ void ThreadStackTrace::dump_stack_at_safepoint(int maxDepth, ObjectMonitorsHasht
 
   if (_with_locked_monitors) {
     // Iterate inflated monitors and find monitors locked by this thread
-    // and not found in the stack:
+    // that are not found in the stack, e.g. JNI locked monitors:
     InflatedMonitorsClosure imc(this);
     if (table != nullptr) {
-      // Get the ObjectMonitors locked by this thread (if any):
+      // Get the ObjectMonitors locked by the target thread, if any,
+      // and does not include any where owner is set to a stack lock
+      // address in the target thread:
       ObjectMonitorsHashtable::PtrList* list = table->get_entry(_thread);
       if (list != nullptr) {
         ObjectSynchronizer::monitors_iterate(&imc, list, _thread);

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -659,7 +659,7 @@ ThreadStackTrace::~ThreadStackTrace() {
   }
 }
 
-void ThreadStackTrace::dump_stack_at_safepoint(int maxDepth) {
+void ThreadStackTrace::dump_stack_at_safepoint(int maxDepth, ObjectMonitorsHashtable* table) {
   assert(SafepointSynchronize::is_at_safepoint(), "all threads are stopped");
 
   if (_thread->has_last_Java_frame()) {
@@ -683,9 +683,17 @@ void ThreadStackTrace::dump_stack_at_safepoint(int maxDepth) {
 
   if (_with_locked_monitors) {
     // Iterate inflated monitors and find monitors locked by this thread
-    // not found in the stack
+    // and not found in the stack:
     InflatedMonitorsClosure imc(this);
-    ObjectSynchronizer::monitors_iterate(&imc, _thread);
+    if (table != nullptr) {
+      // Get the ObjectMonitors locked by this thread (if any):
+      ObjectMonitorsHashtable::PtrList* list = table->get_entry(_thread);
+      if (list != nullptr) {
+        ObjectSynchronizer::monitors_iterate(&imc, list, _thread);
+      }
+    } else {
+      ObjectSynchronizer::monitors_iterate(&imc, _thread);
+    }
   }
 }
 
@@ -936,9 +944,10 @@ ThreadSnapshot::~ThreadSnapshot() {
   delete _concurrent_locks;
 }
 
-void ThreadSnapshot::dump_stack_at_safepoint(int max_depth, bool with_locked_monitors) {
+void ThreadSnapshot::dump_stack_at_safepoint(int max_depth, bool with_locked_monitors,
+                                             ObjectMonitorsHashtable* table) {
   _stack_trace = new ThreadStackTrace(_thread, with_locked_monitors);
-  _stack_trace->dump_stack_at_safepoint(max_depth);
+  _stack_trace->dump_stack_at_safepoint(max_depth, table);
 }
 
 

--- a/src/hotspot/share/services/threadService.hpp
+++ b/src/hotspot/share/services/threadService.hpp
@@ -247,7 +247,8 @@ public:
   ThreadStackTrace* get_stack_trace()     { return _stack_trace; }
   ThreadConcurrentLocks* get_concurrent_locks()     { return _concurrent_locks; }
 
-  void        dump_stack_at_safepoint(int max_depth, bool with_locked_monitors);
+  void        dump_stack_at_safepoint(int max_depth, bool with_locked_monitors,
+                                      ObjectMonitorsHashtable* table);
   void        set_concurrent_locks(ThreadConcurrentLocks* l) { _concurrent_locks = l; }
   void        metadata_do(void f(Metadata*));
 };
@@ -270,7 +271,7 @@ class ThreadStackTrace : public CHeapObj<mtInternal> {
   int             get_stack_depth()     { return _depth; }
 
   void            add_stack_frame(javaVFrame* jvf);
-  void            dump_stack_at_safepoint(int max_depth);
+  void            dump_stack_at_safepoint(int max_depth, ObjectMonitorsHashtable* table);
   Handle          allocate_fill_stack_trace_element_array(TRAPS);
   void            metadata_do(void f(Metadata*));
   GrowableArray<OopHandle>* jni_locked_monitors() { return _jni_locked_monitors; }


### PR DESCRIPTION
RunThese24H sometimes times out with a couple of error msgs:
- "java.lang.management.ThreadInfo.getLockName()" is null
- ForkJoin common pool thread stuck

The '"java.lang.management.ThreadInfo.getLockName()" is null' error msg was
due to RunThese's use of an older JCK test suite which has since been fixed.

The 'ForkJoin common pool thread stuck' failure mode is likely due to a thread
spending a lot of time in ObjectSynchronizer::monitors_iterate() due to a
VM_ThreadDump::doit() call. I say "likely" because I've never been able to
reproduce this failure mode in testing outside of Mach5. With the Mach5
sightings, all we have are thread dumps and core files and not a live process.

The VM_ThreadDump::doit() call is trying to gather owned monitor information
for all threads in the system. I've seen sightings of this failure mode with > 2000
threads. I've also seen passing runs with > 1.7 million monitors on the in-use list.
Imagine searching a larger in-use list for > 2000 threads. It just doesn't scale.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273107](https://bugs.openjdk.java.net/browse/JDK-8273107): RunThese24H times out with "java.lang.management.ThreadInfo.getLockName()" is null


### Reviewers
 * [Robbin Ehn](https://openjdk.java.net/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to d1ca83e7d4a4304c4b502d6adfb551bd8dcf4f11
 * [Coleen Phillimore](https://openjdk.java.net/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to d1ca83e7d4a4304c4b502d6adfb551bd8dcf4f11
 * [Erik Österlund](https://openjdk.java.net/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to d1ca83e7d4a4304c4b502d6adfb551bd8dcf4f11


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/25.diff">https://git.openjdk.java.net/jdk18/pull/25.diff</a>

</details>
