### PR TITLE
8275638: GraphKit::combine_exception_states fails with "matching stack sizes" assert

### DIFF
--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -416,6 +416,7 @@ class LateInlineMHCallGenerator : public LateInlineCallGenerator {
 };
 
 bool LateInlineMHCallGenerator::do_late_inline_check(Compile* C, JVMState* jvms) {
+  assert(!jvms->method()->has_exception_handlers(), "");
   // Even if inlining is not allowed, a virtual call can be strength-reduced to a direct call.
   bool allow_inline = C->inlining_incrementally();
   bool input_not_const = true;

--- a/src/hotspot/share/opto/callGenerator.cpp
+++ b/src/hotspot/share/opto/callGenerator.cpp
@@ -416,7 +416,11 @@ class LateInlineMHCallGenerator : public LateInlineCallGenerator {
 };
 
 bool LateInlineMHCallGenerator::do_late_inline_check(Compile* C, JVMState* jvms) {
-  assert(!jvms->method()->has_exception_handlers(), "");
+  // When inlining a virtual call, the null check at the call and the call itself can throw. These 2 paths have different
+  // expression stacks which causes late inlining to break. The MH invoker is not expected to be called from a method wih
+  // exception handlers. When there is no exception handler, GraphKit::builtin_throw() pops the stack which solves the issue
+  // of late inlining with exceptions.
+  assert(!jvms->method()->has_exception_handlers(), "no exception handler expected");
   // Even if inlining is not allowed, a virtual call can be strength-reduced to a direct call.
   bool allow_inline = C->inlining_incrementally();
   bool input_not_const = true;

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -345,7 +345,6 @@ void GraphKit::combine_exception_states(SafePointNode* ex_map, SafePointNode* ph
   JVMState* ex_jvms = ex_map->_jvms;
   assert(ex_jvms->same_calls_as(phi_map->_jvms), "consistent call chains");
   assert(ex_jvms->stkoff() == phi_map->_jvms->stkoff(), "matching locals");
-//  assert(ex_jvms->sp() == phi_map->_jvms->sp(), "matching stack sizes");
   assert(ex_jvms->monoff() == phi_map->_jvms->monoff(), "matching JVMS");
   assert(ex_jvms->scloff() == phi_map->_jvms->scloff(), "matching scalar replaced objects");
   assert(ex_map->req() == phi_map->req(), "matching maps");
@@ -408,7 +407,7 @@ void GraphKit::combine_exception_states(SafePointNode* ex_map, SafePointNode* ph
   }
   uint limit = ex_map->req();
   for (uint i = TypeFunc::Parms; i < limit; i++) {
-    // Skip everything in the JVMS after tos.  (The ex_oop follows.)
+    // Skip everything in the JVMS after the stack (included).  (The ex_oop follows.)
     if (i == ex_jvms->stkoff())  i = ex_jvms->monoff();
     Node* src = ex_map->in(i);
     Node* dst = phi_map->in(i);

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -615,6 +615,8 @@ void GraphKit::builtin_throw(Deoptimization::DeoptReason reason, Node* arg) {
       Node *store = access_store_at(ex_node, adr, adr_typ, null(), val_type, T_OBJECT, IN_HEAP);
 
       if (!method()->has_exception_handlers()) {
+        // We don't need to preserve the stack if there's no handler as the entire frame is going to be popped anyway.
+        // This prevents issues with exception handling and late inlining.
         set_sp(0);
         clean_stack(0);
       }

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -345,11 +345,10 @@ void GraphKit::combine_exception_states(SafePointNode* ex_map, SafePointNode* ph
   JVMState* ex_jvms = ex_map->_jvms;
   assert(ex_jvms->same_calls_as(phi_map->_jvms), "consistent call chains");
   assert(ex_jvms->stkoff() == phi_map->_jvms->stkoff(), "matching locals");
-  assert(ex_jvms->sp() == phi_map->_jvms->sp(), "matching stack sizes");
+//  assert(ex_jvms->sp() == phi_map->_jvms->sp(), "matching stack sizes");
   assert(ex_jvms->monoff() == phi_map->_jvms->monoff(), "matching JVMS");
   assert(ex_jvms->scloff() == phi_map->_jvms->scloff(), "matching scalar replaced objects");
   assert(ex_map->req() == phi_map->req(), "matching maps");
-  uint tos = ex_jvms->stkoff() + ex_jvms->sp();
   Node*         hidden_merge_mark = root();
   Node*         region  = phi_map->control();
   MergeMemNode* phi_mem = phi_map->merged_memory();
@@ -410,7 +409,7 @@ void GraphKit::combine_exception_states(SafePointNode* ex_map, SafePointNode* ph
   uint limit = ex_map->req();
   for (uint i = TypeFunc::Parms; i < limit; i++) {
     // Skip everything in the JVMS after tos.  (The ex_oop follows.)
-    if (i == tos)  i = ex_jvms->monoff();
+    if (i == ex_jvms->stkoff())  i = ex_jvms->monoff();
     Node* src = ex_map->in(i);
     Node* dst = phi_map->in(i);
     if (src != dst) {

--- a/src/hotspot/share/opto/graphKit.cpp
+++ b/src/hotspot/share/opto/graphKit.cpp
@@ -345,9 +345,11 @@ void GraphKit::combine_exception_states(SafePointNode* ex_map, SafePointNode* ph
   JVMState* ex_jvms = ex_map->_jvms;
   assert(ex_jvms->same_calls_as(phi_map->_jvms), "consistent call chains");
   assert(ex_jvms->stkoff() == phi_map->_jvms->stkoff(), "matching locals");
+  assert(ex_jvms->sp() == phi_map->_jvms->sp(), "matching stack sizes");
   assert(ex_jvms->monoff() == phi_map->_jvms->monoff(), "matching JVMS");
   assert(ex_jvms->scloff() == phi_map->_jvms->scloff(), "matching scalar replaced objects");
   assert(ex_map->req() == phi_map->req(), "matching maps");
+  uint tos = ex_jvms->stkoff() + ex_jvms->sp();
   Node*         hidden_merge_mark = root();
   Node*         region  = phi_map->control();
   MergeMemNode* phi_mem = phi_map->merged_memory();
@@ -407,8 +409,8 @@ void GraphKit::combine_exception_states(SafePointNode* ex_map, SafePointNode* ph
   }
   uint limit = ex_map->req();
   for (uint i = TypeFunc::Parms; i < limit; i++) {
-    // Skip everything in the JVMS after the stack (included).  (The ex_oop follows.)
-    if (i == ex_jvms->stkoff())  i = ex_jvms->monoff();
+    // Skip everything in the JVMS after tos.  (The ex_oop follows.)
+    if (i == tos)  i = ex_jvms->monoff();
     Node* src = ex_map->in(i);
     Node* dst = phi_map->in(i);
     if (src != dst) {
@@ -611,6 +613,11 @@ void GraphKit::builtin_throw(Deoptimization::DeoptReason reason, Node* arg) {
       Node *adr = basic_plus_adr(ex_node, ex_node, offset);
       const TypeOopPtr* val_type = TypeOopPtr::make_from_klass(env()->String_klass());
       Node *store = access_store_at(ex_node, adr, adr_typ, null(), val_type, T_OBJECT, IN_HEAP);
+
+      if (!method()->has_exception_handlers()) {
+        set_sp(0);
+        clean_stack(0);
+      }
 
       add_exception_state(make_exception_state(ex_node));
       return;

--- a/test/hotspot/jtreg/compiler/exceptions/TestLateMHInlineExceptions.java
+++ b/test/hotspot/jtreg/compiler/exceptions/TestLateMHInlineExceptions.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8275638
+ * @summary GraphKit::combine_exception_states fails with "matching stack sizes" assert
+ *
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:CompileCommand=dontinline,TestLateMHInlineExceptions::m -XX:+AlwaysIncrementalInline TestLateMHInlineExceptions
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:+AlwaysIncrementalInline TestLateMHInlineExceptions
+ *
+ */
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class TestLateMHInlineExceptions {
+    public static void main(String[] args) throws Throwable {
+        TestLateMHInlineExceptions test = new TestLateMHInlineExceptions();
+        for (int i = 0; i < 20_000; i++) {
+            test1(test);
+            try {
+                test1(null);
+            } catch (NullPointerException npe) {
+            }
+            test2(test);
+            test2(null);
+        }
+    }
+
+    void m() {
+    }
+
+    static final MethodHandle mh;
+
+    static {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        try {
+            mh = lookup.findVirtual(TestLateMHInlineExceptions.class, "m", MethodType.methodType(void.class));
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Method handle lookup failed");
+        } catch (IllegalAccessException e) {
+            e.printStackTrace();
+            throw new RuntimeException("Method handle lookup failed");
+        }
+    }
+
+    private static void test1(TestLateMHInlineExceptions test) throws Throwable {
+        mh.invokeExact(test);
+    }
+
+    private static void test2(TestLateMHInlineExceptions test) throws Throwable {
+        try {
+            mh.invokeExact(test);
+        } catch (NullPointerException npe) {
+        }
+    }
+
+}

--- a/test/hotspot/jtreg/compiler/exceptions/TestLateMHInlineExceptions.java
+++ b/test/hotspot/jtreg/compiler/exceptions/TestLateMHInlineExceptions.java
@@ -26,8 +26,10 @@
  * @bug 8275638
  * @summary GraphKit::combine_exception_states fails with "matching stack sizes" assert
  *
- * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:CompileCommand=dontinline,TestLateMHInlineExceptions::m -XX:+AlwaysIncrementalInline TestLateMHInlineExceptions
- * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:+AlwaysIncrementalInline TestLateMHInlineExceptions
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:CompileCommand=dontinline,TestLateMHInlineExceptions::m
+ *                   -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline TestLateMHInlineExceptions
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacements -XX:+IgnoreUnrecognizedVMOptions -XX:+AlwaysIncrementalInline
+ *                   TestLateMHInlineExceptions
  *
  */
 

--- a/test/hotspot/jtreg/compiler/exceptions/TestLateMHInlineExceptions.java
+++ b/test/hotspot/jtreg/compiler/exceptions/TestLateMHInlineExceptions.java
@@ -48,6 +48,13 @@ public class TestLateMHInlineExceptions {
             }
             test2(test);
             test2(null);
+            test3(test);
+            try {
+                test3(null);
+            } catch (NullPointerException npe) {
+            }
+            test4(test);
+            test4(null);
         }
     }
 
@@ -80,4 +87,19 @@ public class TestLateMHInlineExceptions {
         }
     }
 
+    private static void inlined(TestLateMHInlineExceptions test) throws Throwable {
+        mh.invokeExact(test);
+    }
+    
+    
+    private static void test3(TestLateMHInlineExceptions test) throws Throwable {
+        inlined(test);
+    }
+
+    private static void test4(TestLateMHInlineExceptions test) throws Throwable {
+        try {
+            inlined(test);
+        } catch (NullPointerException npe) {
+        }
+    }
 }

--- a/test/hotspot/jtreg/compiler/exceptions/TestLateMHInlineExceptions.java
+++ b/test/hotspot/jtreg/compiler/exceptions/TestLateMHInlineExceptions.java
@@ -90,8 +90,8 @@ public class TestLateMHInlineExceptions {
     private static void inlined(TestLateMHInlineExceptions test) throws Throwable {
         mh.invokeExact(test);
     }
-    
-    
+
+
     private static void test3(TestLateMHInlineExceptions test) throws Throwable {
         inlined(test);
     }


### PR DESCRIPTION
The bug and fix were discussed in a previous PR:

https://github.com/openjdk/jdk/pull/6572

I pushed all commits from that PR on top of jdk 18 and added a couple
extra tests as suggested in:

https://github.com/openjdk/jdk/pull/6572#issuecomment-994086590

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275638](https://bugs.openjdk.java.net/browse/JDK-8275638): GraphKit::combine_exception_states fails with "matching stack sizes" assert


### Reviewers
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/29.diff">https://git.openjdk.java.net/jdk18/pull/29.diff</a>

</details>
