### PR TITLE
8278604 SwingSet2 table demo does not have accessible description set for images

### DIFF
--- a/src/demo/share/jfc/SwingSet2/TableDemo.java
+++ b/src/demo/share/jfc/SwingSet2/TableDemo.java
@@ -768,4 +768,13 @@ public class TableDemo extends DemoModule {
         footerTextField.setDragEnabled(dragEnabled);
     }
 
+    @Override
+    public ImageIcon createImageIcon(String filename, String description) {
+        ImageIcon imageIcon = super.createImageIcon(filename, description);
+        AccessibleContext context = imageIcon.getAccessibleContext();
+        if (context!= null) {
+            context.setAccessibleName(description);
+        }
+        return imageIcon;
+    }
 }


### PR DESCRIPTION
SwingSet2 demo is often used to check accessibility for different Swing components and has some shortcomings. The major one is that images within the table demo do not have accessible description set which makes accessibility perform differently on different platforms when navigating the table with screen narrator enabled.

This is the next step after the solution [JDK-8277497](https://bugs.openjdk.java.net/browse/JDK-8277497), in which we forwarded the description from the icon into the label description so that this fix was possible.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issues
 * [JDK-8278604](https://bugs.openjdk.java.net/browse/JDK-8278604): SwingSet2 table demo does not have accessible description set for images
 * [JDK-8278526](https://bugs.openjdk.java.net/browse/JDK-8278526): [macos] Screen reader reads SwingSet2 JTable row selection as null, dimmed row for last column


### Reviewers
 * [Anton Tarasov](https://openjdk.java.net/census#ant) (@forantar - **Reviewer**)
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Pankaj Bansal](https://openjdk.java.net/census#pbansal) - **Reviewer** ⚠️ Added manually

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/31.diff">https://git.openjdk.java.net/jdk18/pull/31.diff</a>

</details>
