### PR TITLE
8278851: Correct signer logic for jars signed with multiple digestalgs

### DIFF
--- a/test/jdk/sun/security/tools/jarsigner/JarWithOneNonDisabledDigestAlg.java
+++ b/test/jdk/sun/security/tools/jarsigner/JarWithOneNonDisabledDigestAlg.java
@@ -23,8 +23,8 @@
 
 /*
  * @test
- * @bug 1111111
- * @summary weakly signed jars test
+ * @bug 8278851 
+ * @summary Correct signer logic for jars signed with multiple weak digestalgs
  * @library /test/lib
  * @build jdk.test.lib.util.JarUtils
  *        jdk.test.lib.security.SecurityUtils

--- a/test/jdk/sun/security/tools/jarsigner/JarWithOneNonDisabledDigestAlg.java
+++ b/test/jdk/sun/security/tools/jarsigner/JarWithOneNonDisabledDigestAlg.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8278851 
+ * @bug 8278851
  * @summary Correct signer logic for jars signed with multiple weak digestalgs
  * @library /test/lib
  * @build jdk.test.lib.util.JarUtils

--- a/test/jdk/sun/security/tools/jarsigner/JarWithOneNonDisabledDigestAlg.java
+++ b/test/jdk/sun/security/tools/jarsigner/JarWithOneNonDisabledDigestAlg.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 1111111
+ * @summary weakly signed jars test
+ * @library /test/lib
+ * @build jdk.test.lib.util.JarUtils
+ *        jdk.test.lib.security.SecurityUtils
+ * @run main/othervm JarWithOneNonDisabledDigestAlg
+ */
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.CodeSigner;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Locale;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+import jdk.test.lib.security.SecurityUtils;
+import jdk.test.lib.util.JarUtils;
+
+public class JarWithOneNonDisabledDigestAlg {
+
+    static final String JARNAME = "signed.jar";
+    private static final String KEYSTORE = "keystore.jks";
+    private static final String SHA256ALIAS = "SHA256ALIAS";
+    private static final String SHA1ALIAS = "SHA1ALIAS";
+    private static final String MD5ALIAS = "MD5ALIAS";
+    private static final String STOREPASS = "changeit";
+    private static final String KEYPASS = "changeit";
+    private static final String TESTFILE = "testfile";
+
+    public static void main(String[] args) throws Throwable {
+        SecurityUtils.removeFromDisabledAlgs("jdk.jar.disabledAlgorithms", List.of("SHA1"));
+        Files.write(Path.of(TESTFILE), "testFile".getBytes());
+        JarUtils.createJarFile(Path.of(JARNAME), Path.of("."), Path.of(TESTFILE));
+        SecurityUtils.genKeyPair(KEYSTORE, SHA256ALIAS, STOREPASS, KEYPASS, "rsa", "SHA256withRSA");
+        SecurityUtils.genKeyPair(KEYSTORE, SHA1ALIAS, STOREPASS, KEYPASS, "rsa", "SHA1withRSA");
+        SecurityUtils.genKeyPair(KEYSTORE, MD5ALIAS, STOREPASS, KEYPASS, "rsa", "MD5withRSA");
+
+        SecurityUtils.signJarFile(JARNAME, KEYSTORE, STOREPASS, KEYPASS, "MD5", SHA1ALIAS).shouldHaveExitValue(0);
+        SecurityUtils.signJarFile(JARNAME, KEYSTORE, STOREPASS, KEYPASS, "SHA1", SHA1ALIAS).shouldHaveExitValue(0);
+        //SecurityUtils.signJarFile(JARNAME, KEYSTORE, STOREPASS, KEYPASS, "SHA-256", SHA1ALIAS).shouldHaveExitValue(0);
+
+
+        try (JarFile jf = new JarFile(JARNAME, true)) {
+            Enumeration<JarEntry> entries = jf.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry entry = entries.nextElement();
+                if (entry.isDirectory() || isSigningRelated(entry.getName())) {
+                    continue;
+                }
+                InputStream is = jf.getInputStream(entry);
+                while (is.read() != -1);
+                CodeSigner[] signers = entry.getCodeSigners();
+                if (signers == null) {
+                    throw new Exception("JarEntry " + entry.getName() +
+                        " is not signed");
+                }
+            }
+        }
+    }
+
+    private static boolean isSigningRelated(String name) {
+        name = name.toUpperCase(Locale.ENGLISH);
+        if (!name.startsWith("META-INF/")) {
+            return false;
+        }
+        name = name.substring(9);
+        if (name.indexOf('/') != -1) {
+            return false;
+        }
+        return name.endsWith(".SF")
+            || name.endsWith(".DSA")
+            || name.endsWith(".RSA")
+            || name.endsWith(".EC")
+            || name.equals("MANIFEST.MF");
+    }
+}
+

--- a/test/lib/jdk/test/lib/security/SecurityUtils.java
+++ b/test/lib/jdk/test/lib/security/SecurityUtils.java
@@ -24,11 +24,18 @@
 package jdk.test.lib.security;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.Security;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
 
 /**
  * Common library for various security test helper functions.
@@ -102,6 +109,99 @@ public final class SecurityUtils {
            }
         }
         return false;
+    }
+
+    /**
+     * Sign a jar file (overwrite original file)
+     *
+     * @param src the original jar file name
+     * @param ks keystore to use
+     * @param storePass the keystore password
+     * @param keyPass the key password
+     * @param digestAlg digest algorithm
+     * @param alias alias to use
+     *
+     * @throws IOException
+     */
+    public static OutputAnalyzer signJarFile(String src, String ks,
+                                             String storePass, String keyPass, String digestAlg, String alias) throws Throwable {
+        return signJarFile(src, src, ks, storePass, keyPass, digestAlg, alias);
+    }
+
+    /**
+     * Sign a jar file
+     *
+     * @param src the original jar file name
+     * @param dest the new/signed jar file name
+     * @param ks keystore to use
+     * @param storePass the keystore password
+     * @param keyPass the key password
+     * @param digestAlg digest algorithm
+     * @param alias alias to use
+     *
+     * @throws Throwable
+     */
+    public static OutputAnalyzer signJarFile(String src, String dest, String ks,
+                                   String storePass, String keyPass, String digestAlg, String alias) throws Throwable {
+        List<String> args = new ArrayList<>();
+        args.add("-verbose");
+        args.add("-signedjar");
+        args.add(dest);
+        args.add("-keystore");
+        args.add(ks);
+        args.add("-storepass");
+        args.add(storePass);
+        args.add("-keypass");
+        args.add(keyPass);
+        args.add("-digestalg");
+        args.add(digestAlg);
+        args.add(src);
+        args.add(alias);
+        return jarsigner(args).shouldHaveExitValue(0);
+    }
+
+    private static OutputAnalyzer jarsigner(List<String> extra)
+            throws Throwable {
+        jdk.test.lib.JDKToolLauncher launcher = jdk.test.lib.JDKToolLauncher.createUsingTestJDK("jarsigner")
+                .addVMArg("-Duser.language=en")
+                .addVMArg("-Duser.country=US");
+        for (String s : extra) {
+            if (s.startsWith("-J")) {
+                launcher.addVMArg(s.substring(2));
+            } else {
+                launcher.addToolArg(s);
+            }
+        }
+        return ProcessTools.executeCommand(launcher.getCommand());
+    }
+
+    /**
+     * Generate a key pair and store in specified keystore
+     *
+     * @param ks path to keystore
+     * @param alias alias to use in new key pair
+     * @param storepass storepass
+     * @param keypass keypass
+     * @param keyAlg key algorithm
+     * @param sigAlg signature algorithm
+     *
+     * @throws Throwable
+     */
+    public static void genKeyPair(String ks, String alias, String storepass,
+                                  String keypass, String keyAlg, String sigAlg) throws Throwable {
+        String keytool = jdk.test.lib.JDKToolFinder.getJDKTool("keytool");
+        jdk.test.lib.process.ProcessTools.executeCommand(keytool,
+                "-J-Duser.language=en",
+                "-J-Duser.country=US",
+                "-genkeypair",
+                "-keyalg", keyAlg,
+                "-sigalg", sigAlg,
+                "-alias", alias,
+                "-keystore", ks,
+                "-keypass", keypass,
+                "-dname", "cn=sample",
+                "-storepass", storepass
+        ).shouldHaveExitValue(0);
     }
 
     private SecurityUtils() {}


### PR DESCRIPTION
The manifest entry verifier exits too quickly in the case where multiple digests are used in a JarEntry and weak digests are present.

I've introduced some test test library functionality to help with jar signing. I've retrofitted one of my earlier tests with that new functionality also in this PR.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8278851](https://bugs.openjdk.java.net/browse/JDK-8278851): Correct signer logic for jars signed with multiple digestalgs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/32/head:pull/32` \
`$ git checkout pull/32`

Update a local copy of the PR: \
`$ git checkout pull/32` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/32/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 32`

View PR using the GUI difftool: \
`$ git pr show -t 32`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/32.diff">https://git.openjdk.java.net/jdk18/pull/32.diff</a>

</details>
