### PR TITLE
8278574: update --help-extra message to include default value of --finalization option

### DIFF
--- a/src/java.base/share/classes/sun/launcher/resources/launcher.properties
+++ b/src/java.base/share/classes/sun/launcher/resources/launcher.properties
@@ -196,8 +196,9 @@ java.launcher.X.usage=\n\
 \    --source <version>\n\
 \                      set the version of the source in source-file mode.\n\
 \    --finalization=<value>\n\
-\                      controls finalization\n\
-\                      <value> is one of "enabled" or "disabled"\n\n\
+\                      controls whether the JVM performs finalization of objects,\n\
+\                      where <value> is one of "enabled" or "disabled".\n\
+\                      Finalization is enabled by default.\n\n\
 These extra options are subject to change without notice.\n
 
 # Translators please note do not translate the options themselves


### PR DESCRIPTION
A small modification to the Launcher's help text.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278574](https://bugs.openjdk.java.net/browse/JDK-8278574): update --help-extra message to include default value of --finalization option


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.java.net/census#sundar) (@sundararajana - **Reviewer**)
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Lance Andersen](https://openjdk.java.net/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/34.diff">https://git.openjdk.java.net/jdk18/pull/34.diff</a>

</details>
