### PR TITLE
8278790: Inner loop of long loop nest runs for too few iterations

### DIFF
--- a/src/hotspot/share/opto/loopnode.cpp
+++ b/src/hotspot/share/opto/loopnode.cpp
@@ -830,10 +830,6 @@ bool PhaseIdealLoop::create_loop_nest(IdealLoopTree* loop, Node_List &old_new) {
     return false;
   }
 
-  // May not have gone thru igvn yet so don't use _igvn.type(phi) (PhaseIdealLoop::is_counted_loop() sets the iv phi's type)
-  const TypeInteger* phi_t = phi->bottom_type()->is_integer(bt);
-  assert(phi_t->hi_as_long() >= phi_t->lo_as_long(), "dead phi?");
-  iters_limit = checked_cast<int>(MIN2((julong)iters_limit, (julong)(phi_t->hi_as_long() - phi_t->lo_as_long())));
 
   IfNode* exit_test = head->loopexit();
   BoolTest::mask mask = exit_test->as_BaseCountedLoopEnd()->test_trip();
@@ -850,6 +846,11 @@ bool PhaseIdealLoop::create_loop_nest(IdealLoopTree* loop, Node_List &old_new) {
       return false;
     }
   }
+
+  // May not have gone thru igvn yet so don't use _igvn.type(phi) (PhaseIdealLoop::is_counted_loop() sets the iv phi's type)
+  const TypeInteger* phi_t = phi->bottom_type()->is_integer(bt);
+  assert(phi_t->hi_as_long() >= phi_t->lo_as_long(), "dead phi?");
+  iters_limit = checked_cast<int>(MIN2((julong)iters_limit, (julong)(phi_t->hi_as_long() - phi_t->lo_as_long())));
 
   // We need a safepoint to insert empty predicates for the inner loop.
   SafePointNode* safepoint;


### PR DESCRIPTION
Given a counted loop that iterates in [A, Z), when long range checks
are transformed into int range checks, a loop nest is created and
the inner loop iterates in [0, Z2).

The limits of the inner loop are adjusted to guarantee no overflow for
the range of values of the inner loop. That is for a range check:

i * scale + offset <u length

1) the bounds of the inner loop are adjusted to roughly [0,
max_jint/scale).

Also, we don't want to loose what we know about the bounds of the loop
being transformed.

2) So the bound of the inner loop are also adjusted to [0, min(Z2, Z - A))

The bug here is that 2) is performed before 1). This was spotted with
a micro benchmarks where the initial loop had only ~2000
iterations. The transformed loop is expected to run for the same 2000
iterations but instead ran for 2000/scale iterations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278790](https://bugs.openjdk.java.net/browse/JDK-8278790): Inner loop of long loop nest runs for too few iterations


### Reviewers
 * [Christian Hagedorn](https://openjdk.java.net/census#chagedorn) (@chhagedorn - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/35.diff">https://git.openjdk.java.net/jdk18/pull/35.diff</a>

</details>
