### PR TITLE
JDK-8273452: DocTrees.getDocCommentTree should be specified as idempotent

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTrees.java
@@ -87,6 +87,10 @@ public abstract class DocTrees extends Trees {
     /**
      * Returns the doc comment tree, if any, for the Tree node identified by a given TreePath.
      * Returns {@code null} if no doc comment was found.
+     * @implNote The implementation of this method returns the same
+     * {@code DocCommentTree} instance for repeated invocations
+     * with the same argument.
+     *
      * @param path the path for the tree node
      * @return the doc comment tree
      */
@@ -95,6 +99,10 @@ public abstract class DocTrees extends Trees {
     /**
      * Returns the doc comment tree of the given element.
      * Returns {@code null} if no doc comment was found.
+     * @implNote The implementation of this method returns the same
+     * {@code DocCommentTree} instance for repeated invocations
+     * with the same argument.
+     *
      * @param e an element whose documentation is required
      * @return the doc comment tree
      *
@@ -108,6 +116,8 @@ public abstract class DocTrees extends Trees {
      * entire contents of the file.
      * Returns {@code null} if no doc comment was found.
      * Future releases may support additional file types.
+     * @implNote The implementation of this method returns a
+     * new {@code DocCommentTree} instance for each invocation.
      *
      * @param fileObject the content container
      * @return the doc comment tree
@@ -122,6 +132,8 @@ public abstract class DocTrees extends Trees {
      * of the &lt;body&gt; tag, and any enclosing tags are ignored.
      * Returns {@code null} if no doc comment was found.
      * Future releases may support additional file types.
+     * @implNote The implementation of this method returns a
+     * new {@code DocCommentTree} instance for each invocation.
      *
      * @param e an element whose path is used as a reference
      * @param relativePath the relative path from the Element

--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTrees.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTrees.java
@@ -87,7 +87,8 @@ public abstract class DocTrees extends Trees {
     /**
      * Returns the doc comment tree, if any, for the Tree node identified by a given TreePath.
      * Returns {@code null} if no doc comment was found.
-     * @implNote The implementation of this method returns the same
+     *
+     * @implNote The default implementation of this method returns the same
      * {@code DocCommentTree} instance for repeated invocations
      * with the same argument.
      *
@@ -99,7 +100,8 @@ public abstract class DocTrees extends Trees {
     /**
      * Returns the doc comment tree of the given element.
      * Returns {@code null} if no doc comment was found.
-     * @implNote The implementation of this method returns the same
+     *
+     * @implNote The default implementation of this method returns the same
      * {@code DocCommentTree} instance for repeated invocations
      * with the same argument.
      *
@@ -116,7 +118,8 @@ public abstract class DocTrees extends Trees {
      * entire contents of the file.
      * Returns {@code null} if no doc comment was found.
      * Future releases may support additional file types.
-     * @implNote The implementation of this method returns a
+     *
+     * @implNote The default implementation of this method returns a
      * new {@code DocCommentTree} instance for each invocation.
      *
      * @param fileObject the content container
@@ -132,7 +135,8 @@ public abstract class DocTrees extends Trees {
      * of the &lt;body&gt; tag, and any enclosing tags are ignored.
      * Returns {@code null} if no doc comment was found.
      * Future releases may support additional file types.
-     * @implNote The implementation of this method returns a
+     *
+     * @implNote The default implementation of this method returns a
      * new {@code DocCommentTree} instance for each invocation.
      *
      * @param e an element whose path is used as a reference


### PR DESCRIPTION
Please review a doc-only change to add implementation notes to the `DocTrees.getDocCommentTree` methods, some of which return the same `DocCommentTree` instance on repeated invocation and some don't. I decided to use `@implNote` instead of `@implSpec` as usually I wouldn't expect object identity to be part of a Java API specification.

I verified the described behavior using code analysis and enhancing existing tests. The latter are not included in the commit as this is a `noreg-doc` issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8273452](https://bugs.openjdk.java.net/browse/JDK-8273452): DocTrees.getDocCommentTree should be specified as idempotent


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to f69a10524539fedbcc79e5ebd91b71134daf014d


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/36.diff">https://git.openjdk.java.net/jdk18/pull/36.diff</a>

</details>
