### PR TITLE
8276826: Clarify the ModuleDescriptor.Version specification’s treatment of repeated punctuation characters

### DIFF
--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -893,7 +893,8 @@ public class ModuleDescriptor
      * integer or a string.  Tokens are separated by the punctuation characters
      * {@code '.'}, {@code '-'}, or {@code '+'}, or by transitions from a
      * sequence of digits to a sequence of characters that are neither digits
-     * nor punctuation characters, or vice versa.
+     * nor punctuation characters, or vice versa.  Consecutive repeated
+     * punctuation characters are treated as a single punctuation character.
      *
      * <ul>
      *


### PR DESCRIPTION
Please review this tiny specification clarification.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8276826](https://bugs.openjdk.java.net/browse/JDK-8276826): Clarify the ModuleDescriptor.Version specification’s treatment of repeated punctuation characters
 * [JDK-8278465](https://bugs.openjdk.java.net/browse/JDK-8278465): Clarify the ModuleDescriptor.Version specification’s treatment of repeated punctuation characters (**CSR**)


### Reviewers
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [Joe Darcy](https://openjdk.java.net/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/39.diff">https://git.openjdk.java.net/jdk18/pull/39.diff</a>

</details>
