### PR TITLE
8277447: Hotspot C1 compiler crashes on Kotlin suspend fun with loop

### DIFF
--- a/src/hotspot/share/c1/c1_Instruction.cpp
+++ b/src/hotspot/share/c1/c1_Instruction.cpp
@@ -801,6 +801,11 @@ bool BlockBegin::try_merge(ValueStack* new_state) {
           existing_state->invalidate_local(index);
           TRACE_PHI(tty->print_cr("invalidating local %d because of type mismatch", index));
         }
+
+        if (existing_value != new_state->local_at(index) && existing_value->as_Phi() == NULL) {
+          TRACE_PHI(tty->print_cr("required phi for local %d is missing, irreducible loop?", index));
+          return false; // BAILOUT in caller
+        }
       }
 
 #ifdef ASSERT

--- a/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathology.jasm
+++ b/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathology.jasm
@@ -22,55 +22,55 @@
  *
  */
 super public class TestC1PhiPlacementPathology
-	version 62:0
+   version 62:0
 {
   public static volatile Field sideEffect:I;
 
   public Method "<init>":"()V"
-	stack 1 locals 1
+   stack 1 locals 1
   {
-		aload_0;
-		invokespecial	Method java/lang/Object."<init>":"()V";
-		return;
+      aload_0;
+      invokespecial   Method java/lang/Object."<init>":"()V";
+      return;
   }
   private static Method effect:"(I)V"
-	stack 2 locals 1
+   stack 2 locals 1
   {
-		getstatic	Field sideEffect:"I";
-		iload_0;
-		iadd;
-		putstatic	Field sideEffect:"I";
-		return;
+      getstatic   Field sideEffect:"I";
+      iload_0;
+      iadd;
+      putstatic   Field sideEffect:"I";
+      return;
   }
   public static Method test:"(I)V"
-	stack 2 locals 2
+   stack 2 locals 2
   {
-		iconst_0;
-		istore_1;
-		iload_0;
-		iconst_2;
-		irem;
-		ifne	MODIFY_LOCAL;
-		iinc	1, 1;
-		goto	LH2;
-	MODIFY_LOCAL:	stack_frame_type append;
-		locals_map int;
-		iinc	1, 2;
-		iinc	0, 1;
+      iconst_0;
+      istore_1;
+      iload_0;
+      iconst_2;
+      irem;
+      ifne   MODIFY_LOCAL;
+      iinc   1, 1;
+      goto   LH2;
+   MODIFY_LOCAL:   stack_frame_type append;
+      locals_map int;
+      iinc   1, 2;
+      iinc   0, 1;
     goto LH1;
-	LH1:	stack_frame_type same;
-		iinc	1, 1;
-		iload_1;
-		sipush	10000;
-		if_icmpge	EXIT;
-	LH2:	stack_frame_type same;
-		iinc	1, 1;
-		goto	LH1;
-	EXIT:	stack_frame_type same;
-		iload_1;
-		iload_0;
-		iadd;
-		invokestatic	Method effect:"(I)V";
-		return;
+   LH1:   stack_frame_type same;
+      iinc   1, 1;
+      iload_1;
+      sipush   10000;
+      if_icmpge   EXIT;
+   LH2:   stack_frame_type same;
+      iinc   1, 1;
+      goto   LH1;
+   EXIT:   stack_frame_type same;
+      iload_1;
+      iload_0;
+      iadd;
+      invokestatic   Method effect:"(I)V";
+      return;
   }
 } // end Class TestC1PhiPlacementPathology

--- a/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathology.jasm
+++ b/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathology.jasm
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+super public class TestC1PhiPlacementPathology
+	version 62:0
+{
+  public static volatile Field sideEffect:I;
+
+  public Method "<init>":"()V"
+	stack 1 locals 1
+  {
+		aload_0;
+		invokespecial	Method java/lang/Object."<init>":"()V";
+		return;
+  }
+  private static Method effect:"(I)V"
+	stack 2 locals 1
+  {
+		getstatic	Field sideEffect:"I";
+		iload_0;
+		iadd;
+		putstatic	Field sideEffect:"I";
+		return;
+  }
+  public static Method test:"(I)V"
+	stack 2 locals 2
+  {
+		iconst_0;
+		istore_1;
+		iload_0;
+		iconst_2;
+		irem;
+		ifne	MODIFY_LOCAL;
+		iinc	1, 1;
+		goto	LH2;
+	MODIFY_LOCAL:	stack_frame_type append;
+		locals_map int;
+		iinc	1, 2;
+		iinc	0, 1;
+    goto LH1;
+	LH1:	stack_frame_type same;
+		iinc	1, 1;
+		iload_1;
+		sipush	10000;
+		if_icmpge	EXIT;
+	LH2:	stack_frame_type same;
+		iinc	1, 1;
+		goto	LH1;
+	EXIT:	stack_frame_type same;
+		iload_1;
+		iload_0;
+		iadd;
+		invokestatic	Method effect:"(I)V";
+		return;
+  }
+} // end Class TestC1PhiPlacementPathology

--- a/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathologyMain.java
+++ b/test/hotspot/jtreg/compiler/c1/TestC1PhiPlacementPathologyMain.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8277447
+ * @summary Test a pathological case for phi placement with an irreducible loop of a particular shape.
+ *
+ * @compile TestC1PhiPlacementPathology.jasm
+ * @run main/othervm -Xbatch -XX:CompileCommand=compileonly,TestC1PhiPlacementPathology::test
+ *                   -XX:CompilationMode=quick-only -XX:-UseOnStackReplacement TestC1PhiPlacementPathologyMain
+ */
+
+public class TestC1PhiPlacementPathologyMain {
+    public static void main(String[] args) {
+        for (int i = 0; i < 11000; i++) {
+            TestC1PhiPlacementPathology.test(0);
+        }
+    }
+}


### PR DESCRIPTION
There are a bunch of problems with `BlockListBuilder::mark_loops()` and how it handles irreducible loops. It doesn't really seem to be explicitly designed to handle those, however, it does handle most. One shape emitted by the Kotlin compiler in this particular case gives it trouble.

The proper fix is to rewrite loop detection, detect irreducible loops, and switch off `SelectivePhiFunctions` is any are present. But given that we're close to the release, I'd like to add a bailout during phi insertion, and file an RFE to do the proper fix later.

I wrote a minimal test to demonstrate the issue.

Testing with hs-tier{1-7} is squeaky clean.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277447](https://bugs.openjdk.java.net/browse/JDK-8277447): Hotspot C1 compiler crashes on Kotlin suspend fun with loop


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/40.diff">https://git.openjdk.java.net/jdk18/pull/40.diff</a>

</details>
