### PR TITLE
8278970: [macos] SigningPackageTest is failed with runtime exception

### DIFF
--- a/test/jdk/tools/jpackage/macosx/SigningPackageTest.java
+++ b/test/jdk/tools/jpackage/macosx/SigningPackageTest.java
@@ -76,9 +76,13 @@ public class SigningPackageTest {
     private static void verifyAppImageInDMG(JPackageCommand cmd) {
         MacHelper.withExplodedDmg(cmd, dmgImage -> {
             Path launcherPath = dmgImage.resolve(Path.of("Contents", "MacOS", cmd.name()));
-            SigningBase.verifyCodesign(launcherPath, true);
-            SigningBase.verifyCodesign(dmgImage, true);
-            SigningBase.verifySpctl(dmgImage, "exec");
+            // We will be called with all folders in DMG since JDK-8263155, but
+            // we only need to verify app.
+            if (dmgImage.endsWith(cmd.name() + ".app")) {
+                SigningBase.verifyCodesign(launcherPath, true);
+                SigningBase.verifyCodesign(dmgImage, true);
+                SigningBase.verifySpctl(dmgImage, "exec");
+            }
         });
     }
 


### PR DESCRIPTION
This is regression from JDK-8263155. MacHelper.java is now calling test verification callback with all content in DMG root. SigningPackageTest expects only path with app name in it and thus it fails when trying to verify app inside ".background" folder. Fixed by checking that provided path for verification is actually an application we expecting. All other paths are ignored.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278970](https://bugs.openjdk.java.net/browse/JDK-8278970): [macos] SigningPackageTest is failed with runtime exception


### Reviewers
 * [Andy Herrick](https://openjdk.java.net/census#herrick) (@andyherrick - **Reviewer**)
 * [Alexey Semenyuk](https://openjdk.java.net/census#asemenyuk) (@alexeysemenyukoracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/42.diff">https://git.openjdk.java.net/jdk18/pull/42.diff</a>

</details>
