### PR TITLE
8206181: ExceptionInInitializerError: improve handling of exceptions in user-provided taglets

### DIFF
--- a/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/ClassCastExceptionTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/ClassCastExceptionTaglet.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.element.Element;
+
+import com.sun.source.doctree.DocTree;
+import jdk.javadoc.doclet.Taglet;
+
+public class ClassCastExceptionTaglet /* does NOT implement jdk.javadoc.doclet.Taglet */ {
+
+    public Set<Taglet.Location> getAllowedLocations() {
+        return EnumSet.allOf(Taglet.Location.class);
+    }
+
+    public boolean isInlineTag() {
+        return false;
+    }
+
+    public String getName() {
+        return "ClassCastExceptionTaglet";
+    }
+
+    public String toString(List<? extends DocTree> tags, Element element) {
+        return "";
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/ExceptionInInitializerErrorTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/ExceptionInInitializerErrorTaglet.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.element.Element;
+
+import com.sun.source.doctree.DocTree;
+import jdk.javadoc.doclet.Taglet;
+
+public class ExceptionInInitializerErrorTaglet implements Taglet {
+
+    static {
+        if (true) {
+            throw new RuntimeException();
+        }
+    }
+
+    @Override
+    public Set<Taglet.Location> getAllowedLocations() {
+        return EnumSet.allOf(Taglet.Location.class);
+    }
+
+    @Override
+    public boolean isInlineTag() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "ExceptionInInitializerErrorTaglet";
+    }
+
+    @Override
+    public String toString(List<? extends DocTree> tags, Element element) {
+        return "";
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/InstantiationExceptionTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/InstantiationExceptionTaglet.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.element.Element;
+
+import com.sun.source.doctree.DocTree;
+import jdk.javadoc.doclet.Taglet;
+
+public abstract class InstantiationExceptionTaglet implements Taglet {
+
+    @Override
+    public Set<Taglet.Location> getAllowedLocations() {
+        return EnumSet.allOf(Taglet.Location.class);
+    }
+
+    @Override
+    public boolean isInlineTag() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "InstantiationExceptionTaglet";
+    }
+
+    @Override
+    public String toString(List<? extends DocTree> tags, Element element) {
+        return "";
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/InvocationTargetExceptionTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/InvocationTargetExceptionTaglet.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.element.Element;
+
+import com.sun.source.doctree.DocTree;
+import jdk.javadoc.doclet.Taglet;
+
+public class InvocationTargetExceptionTaglet implements Taglet {
+
+    public InvocationTargetExceptionTaglet() {
+        throw new RuntimeException();
+    }
+
+    @Override
+    public Set<Location> getAllowedLocations() {
+        return EnumSet.allOf(Location.class);
+    }
+
+    @Override
+    public boolean isInlineTag() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "InvocationTargetExceptionTaglet";
+    }
+
+    @Override
+    public String toString(List<? extends DocTree> tags, Element element) {
+        return "";
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/NoSuchMethodExceptionNoNullaryCtorTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/NoSuchMethodExceptionNoNullaryCtorTaglet.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.element.Element;
+
+import com.sun.source.doctree.DocTree;
+import jdk.javadoc.doclet.Taglet;
+
+public class NoSuchMethodExceptionNoNullaryCtorTaglet implements Taglet {
+
+    public NoSuchMethodExceptionNoNullaryCtorTaglet(Object obj) {}
+
+    @Override
+    public Set<Location> getAllowedLocations() {
+        return EnumSet.allOf(Taglet.Location.class);
+    }
+
+    @Override
+    public boolean isInlineTag() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "NoSuchMethodExceptionNoNullaryCtorTaglet";
+    }
+
+    @Override
+    public String toString(List<? extends DocTree> tags, Element element) {
+        return "";
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/NoSuchMethodExceptionPrivateCtorTaglet.java
+++ b/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/NoSuchMethodExceptionPrivateCtorTaglet.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.element.Element;
+
+import com.sun.source.doctree.DocTree;
+import jdk.javadoc.doclet.Taglet;
+
+public class NoSuchMethodExceptionPrivateCtorTaglet implements Taglet {
+
+    private NoSuchMethodExceptionPrivateCtorTaglet() {}
+
+    @Override
+    public Set<Taglet.Location> getAllowedLocations() {
+        return EnumSet.allOf(Taglet.Location.class);
+    }
+
+    @Override
+    public boolean isInlineTag() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "NoSuchMethodExceptionPrivateCtorTaglet";
+    }
+
+    @Override
+    public String toString(List<? extends DocTree> tags, Element element) {
+        return "";
+    }
+}

--- a/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/TestRegistrationErrors.java
+++ b/test/langtools/jdk/javadoc/doclet/testCustomTagletRegistration/TestRegistrationErrors.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8206181
+ * @library  ../../lib
+ * @modules jdk.javadoc/jdk.javadoc.internal.tool
+ * @build javadoc.tester.* *
+ * @run main TestRegistrationErrors
+ */
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import javadoc.tester.JavadocTester;
+
+public class TestRegistrationErrors extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestRegistrationErrors tester = new TestRegistrationErrors();
+        tester.runTests();
+    }
+
+    @Test
+    public void test() throws Exception {
+        try (Stream<Path> tagletClasses = findTagletClasses()) {
+            tagletClasses.forEach(p -> {
+                String tagletName = getTagletName(p);
+                javadoc("-d", "out-" + tagletName, // a directory per taglet
+                        "-tagletpath", System.getProperty("test.classes"),
+                        "-taglet", tagletName,
+                        testSrc("TestRegistrationErrors.java")); // specify this file
+                checkExit(Exit.ERROR);
+                new OutputChecker(Output.OUT).checkUnique(Pattern.compile("thrown while trying to register Taglet"));
+                checkNoCrashes();
+            });
+        }
+    }
+
+    private static Stream<Path> findTagletClasses() throws IOException {
+        var path = Path.of(System.getProperty("test.classes"));
+        return Files.find(path, Integer.MAX_VALUE,
+                (p, a) -> a.isRegularFile() && p.toString().endsWith("Taglet.class"));
+    }
+
+    private static String getTagletName(Path tagletClass) {
+        Path fileName = tagletClass.getFileName();
+        return fileName.toString().substring(0, fileName.toString().lastIndexOf('.'));
+    }
+
+    protected void checkNoCrashes() {
+        checking("check crashes");
+        Matcher matcher = Pattern.compile("\\s*at.*\\(.*\\.java:\\d+\\)")
+                .matcher(getOutput(Output.STDERR));
+        if (!matcher.find()) {
+            passed("");
+        } else {
+            failed("Looks like a stacktrace: " + matcher.group());
+        }
+    }
+}


### PR DESCRIPTION
Using a custom taglet may result in exceptions, not all of which are javadoc bugs. Some of these exceptions are taglet bugs.

It was noticed that an exception in a static initializer of a custom taglet looks like a javadoc bug, which it is not. The fix was to trivially catch java.lang.ExceptionInInitializerError and translate it into an error like it is already done for some other exceptions.

While working on this fix, I noticed that there were no tests that cover various exceptions that could arise while registering a taglet:

  * ClassNotFoundException
  * NoSuchMethodException
  * InstantiationException
  * InvocationTargetException

I added a test to cover all of those as well as ExceptionInInitializerError and ClassCastException, which I proactively handled similarly to ExceptionInInitializerError.

I note that a typical taglet-registration error message is quite poor and should be improved in the future. For example, it is unclear that the method that javadoc cannot find is the nullary (i.e. parameterless or no-arg) MyTaglet constructor:

    Error - Exception java.lang.NoSuchMethodException thrown while trying to register Taglet MyTaglet...

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8206181](https://bugs.openjdk.java.net/browse/JDK-8206181): ExceptionInInitializerError: improve handling of exceptions in user-provided taglets


### Reviewers
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to 39d087cde4c3216c8f3cb9faa1cfe3470bcadca3


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/44.diff">https://git.openjdk.java.net/jdk18/pull/44.diff</a>

</details>
