### PR TITLE
JDK-8278967 rmiregistry fails to start because SecurityManager is disabled

### DIFF
--- a/make/modules/java.rmi/Launcher.gmk
+++ b/make/modules/java.rmi/Launcher.gmk
@@ -27,5 +27,5 @@ include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, rmiregistry, \
     MAIN_CLASS := sun.rmi.registry.RegistryImpl, \
-    JAVA_ARGS := -Djava.security.manager, \
+    JAVA_ARGS := -Djava.security.manager=allow, \
 ))

--- a/make/modules/java.rmi/Launcher.gmk
+++ b/make/modules/java.rmi/Launcher.gmk
@@ -27,4 +27,5 @@ include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, rmiregistry, \
     MAIN_CLASS := sun.rmi.registry.RegistryImpl, \
+    JAVA_ARGS := -Djava.security.manager, \
 ))

--- a/test/jdk/tools/launcher/VersionCheck.java
+++ b/test/jdk/tools/launcher/VersionCheck.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 6545058 6611182 8016209 8139986 8162746
+ * @bug 6545058 6611182 8016209 8139986 8162746 8278967
  * @summary validate and test -version, -fullversion, and internal, as well as
  *          sanity checks if a tool can be launched.
  * @modules jdk.compiler
@@ -126,9 +126,12 @@ public class VersionCheck extends TestHelper {
     static String getVersion0(boolean allLines, String... argv) {
         TestHelper.TestResult tr = doExec(argv);
         StringBuilder out = new StringBuilder();
-        // remove the HotSpot line
+        // remove the HotSpot line and security manager deprecation warnings
         for (String x : tr.testOutput) {
-            if (allLines || !x.matches(".*Client.*VM.*|.*Server.*VM.*")) {
+            if (allLines || !x.matches(".*Client.*VM.*|" +
+                                       ".*Server.*VM.*|" +
+                                       "WARNING:.*terminally.*deprecated.*|" +
+                                       "WARNING:.*System::setSecurityManager.*")) {
                 out = out.append(x + "\n");
             }
         }


### PR DESCRIPTION
Enable the security manager in rmiregistry's launcher arguments.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278967](https://bugs.openjdk.java.net/browse/JDK-8278967): rmiregistry fails to start because SecurityManager is disabled


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/45.diff">https://git.openjdk.java.net/jdk18/pull/45.diff</a>

</details>
