### PR TITLE
8278987: RunThese24H.java failed with EXCEPTION_ACCESS_VIOLATION in __write_sample_info__

### DIFF
--- a/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
+++ b/src/hotspot/share/jfr/leakprofiler/checkpoint/objectSampleCheckpoint.cpp
@@ -202,7 +202,7 @@ static void prepare_for_resolution() {
 
 static bool stack_trace_precondition(const ObjectSample* sample) {
   assert(sample != NULL, "invariant");
-  return sample->has_stack_trace_id() && !sample->is_dead() && !sample->stacktrace().valid();
+  return sample->has_stack_trace_id() && !sample->is_dead();
 }
 
 class StackTraceBlobInstaller {
@@ -249,7 +249,7 @@ void StackTraceBlobInstaller::install(ObjectSample* sample) {
   writer.write_type(TYPE_STACKTRACE);
   writer.write_count(1);
   ObjectSampleCheckpoint::write_stacktrace(stack_trace, writer);
-  blob = writer.move();
+  blob = writer.copy();
   _cache.put(sample, blob);
   sample->set_stacktrace(blob);
 }
@@ -278,7 +278,7 @@ void ObjectSampleCheckpoint::on_rotation(const ObjectSampler* sampler) {
 }
 
 static bool is_klass_unloaded(traceid klass_id) {
-  assert_locked_or_safepoint(ClassLoaderDataGraph_lock);
+  assert(ClassLoaderDataGraph_lock->owned_by_self(), "invariant");
   return JfrKlassUnloading::is_unloaded(klass_id);
 }
 
@@ -381,12 +381,6 @@ void ObjectSampleCheckpoint::write(const ObjectSampler* sampler, EdgeStore* edge
   assert(sampler != NULL, "invariant");
   assert(edge_store != NULL, "invariant");
   assert(thread != NULL, "invariant");
-  {
-    // First install stacktrace blobs for the most recently added candidates.
-    MutexLocker lock(SafepointSynchronize::is_at_safepoint() ? nullptr : ClassLoaderDataGraph_lock);
-    // the lock is needed to ensure the unload lists do not grow in the middle of inspection.
-    install_stack_traces(sampler);
-  }
   write_sample_blobs(sampler, emit_all, thread);
   // write reference chains
   if (!edge_store->is_empty()) {


### PR DESCRIPTION
Greetings,

JDK-8277919 tried to reduce the number of stacktraces that were serialized per chunk for leak profiler candidate objects.

To serialize the stacktrace for a leak profiler candidate object, one must ensure not to reference an already unloaded klass / method. This is done by inspecting an unloaded list. To protect this list from growing (and from being reallocated), it is protected under the ClassLoaderDataGraph_lock.

By taking the ClassLoaderDataGraph_lock, a safepoint is now introduced in the code that did not safepoint previously. This means the objects on the list to be serialized can now be gc'd. Indeed, there is a crash where the serialization logic attempts to read the klass for an object that has now been gc'd.

I need to restore this attempt - there are other ways to reduce the number of traces serialized for new leak profiler candidates in each chunk, which are a very small number by default anyways. Also, the need to use the unloaded list during serialization is removed in future branches.

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278987](https://bugs.openjdk.java.net/browse/JDK-8278987): RunThese24H.java failed with EXCEPTION_ACCESS_VIOLATION in __write_sample_info__


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.java.net/census#jbachorik) (@jbachorik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/47.diff">https://git.openjdk.java.net/jdk18/pull/47.diff</a>

</details>
