### PR TITLE
8279011: JFR: JfrChunkWriter incorrectly handles int64_t chunk size as size_t

### DIFF
--- a/src/hotspot/share/jfr/recorder/repository/jfrChunkWriter.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrChunkWriter.cpp
@@ -207,7 +207,7 @@ int64_t JfrChunkWriter::write_chunk_header_checkpoint(bool flushpoint) {
   const u4 checkpoint_size = current_offset() - event_size_offset;
   write_padded_at_offset<u4>(checkpoint_size, event_size_offset);
   set_last_checkpoint_offset(event_size_offset);
-  const size_t sz_written = size_written();
+  const int64_t sz_written = size_written();
   write_be_at_offset(sz_written, chunk_size_offset);
   return sz_written;
 }


### PR DESCRIPTION
See the investigation in the bug.

Spot the problem:

```
int64_t JfrChunkWriter::write_chunk_header_checkpoint(bool flushpoint) {
   ...
   const size_t sz_written = size_written(); // <-- returns int64_t
   write_be_at_offset(sz_written, chunk_size_offset); // <--- template instantiation with type=size_t
   return sz_written;
 }
```

This would have been nearly fine -- small `size_t` -> `int64_t` conversion is okay value-wise. But `write_be_at_offset` calculates the position for the writeout using `sizeof(T)`, which silently borks the whole thing on at least 32-bit platforms, where `sizeof(size_t)` != `sizeof(int64_t)`. 

Additional testing:
 - [x] Linux x86_64 `jdk_jfr` (no regressions)
 - [x] Linux x86_32 `jdk_jfr` (many failing tests now pass)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279011](https://bugs.openjdk.java.net/browse/JDK-8279011): JFR: JfrChunkWriter incorrectly handles int64_t chunk size as size_t


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/50.diff">https://git.openjdk.java.net/jdk18/pull/50.diff</a>

</details>
