### PR TITLE
8279045: Intrinsics missing vzeroupper instruction

### DIFF
--- a/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
+++ b/src/hotspot/cpu/x86/stubGenerator_x86_64.cpp
@@ -4138,6 +4138,7 @@ class StubGenerator: public StubCodeGenerator {
     const Register len = c_rarg3;  // src len (must be multiple of blocksize 16)
     __ enter(); // required for proper stackwalking of RuntimeStub frame
     __ aesecb_encrypt(from, to, key, len);
+    __ vzeroupper();
     __ leave(); // required for proper stackwalking of RuntimeStub frame
     __ ret(0);
     return start;
@@ -4153,6 +4154,7 @@ class StubGenerator: public StubCodeGenerator {
     const Register len = c_rarg3;  // src len (must be multiple of blocksize 16)
     __ enter(); // required for proper stackwalking of RuntimeStub frame
     __ aesecb_decrypt(from, to, key, len);
+    __ vzeroupper();
     __ leave(); // required for proper stackwalking of RuntimeStub frame
     __ ret(0);
     return start;
@@ -4448,6 +4450,7 @@ class StubGenerator: public StubCodeGenerator {
     __ movptr(counter, counter_mem);
 
     __ aesgcm_encrypt(in, len, ct, out, key, state, subkeyHtbl, avx512_subkeyHtbl, counter);
+    __ vzeroupper();
 
     // Restore state before leaving routine
 #ifdef _WIN64
@@ -4564,6 +4567,7 @@ class StubGenerator: public StubCodeGenerator {
 #endif
     __ push(rbx);
     __ aesctr_encrypt(from, to, key, counter, len_reg, used, used_addr, saved_encCounter_start);
+    __ vzeroupper();
     // Restore state before leaving routine
     __ pop(rbx);
 #ifdef _WIN64
@@ -5184,6 +5188,7 @@ address generate_cipherBlockChaining_decryptVectorAESCrypt() {
     __ evpxorq(RK14, RK14, RK14, Assembler::AVX_512bit);
 
     __ BIND(Lcbc_exit);
+    __ vzeroupper();
     __ pop(rbx);
 #ifdef _WIN64
     __ movl(rax, len_mem);
@@ -7059,6 +7064,7 @@ address generate_avx_ghash_processBlocks() {
     __ shrdl(tmp4, tmp3);
     __ movl(Address(newArr, nIdx, Address::times_4), tmp4);
     __ BIND(Exit);
+    __ vzeroupper();
     // Restore callee save registers.
     __ pop(tmp5);
 #ifdef _WINDOWS
@@ -7180,6 +7186,7 @@ address generate_avx_ghash_processBlocks() {
     __ movl(Address(newArr, idx, Address::times_4), tmp3);
 
     __ BIND(Exit);
+    __ vzeroupper();
     // Restore callee save registers.
     __ pop(tmp5);
 #ifdef _WINDOWS


### PR DESCRIPTION
Adding vzeroupper instruction to aes and shift intrinsics.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279045](https://bugs.openjdk.java.net/browse/JDK-8279045): Intrinsics missing vzeroupper instruction


### Reviewers
 * [Nils Eliasson](https://openjdk.java.net/census#neliasso) (@neliasso - **Reviewer**) ⚠️ Review applies to f80213905112c5cf65704028fbc49d917a27d3dc
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**) ⚠️ Review applies to f80213905112c5cf65704028fbc49d917a27d3dc
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/52.diff">https://git.openjdk.java.net/jdk18/pull/52.diff</a>

</details>
