### PR TITLE
8279007: jstatd fails to start because SecurityManager is disabled

### DIFF
--- a/make/modules/jdk.jstatd/Launcher.gmk
+++ b/make/modules/jdk.jstatd/Launcher.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2011, 2021, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -27,4 +27,5 @@ include LauncherCommon.gmk
 
 $(eval $(call SetupBuildLauncher, jstatd, \
     MAIN_CLASS := sun.tools.jstatd.Jstatd, \
+    JAVA_ARGS := -Djava.security.manager=allow, \
 ))

--- a/test/jdk/sun/tools/jstatd/JstatdTest.java
+++ b/test/jdk/sun/tools/jstatd/JstatdTest.java
@@ -253,7 +253,6 @@ public final class JstatdTest {
     private String[] getJstatdCmd() throws Exception {
         JDKToolLauncher launcher = JDKToolLauncher.createUsingTestJDK("jstatd");
         launcher.addVMArg("-XX:+UsePerfData");
-        launcher.addVMArg("-Djava.security.manager=allow");
         String testSrc = System.getProperty("test.src");
         File policy = new File(testSrc, "all.policy");
         assertTrue(policy.exists() && policy.isFile(),


### PR DESCRIPTION
jstatd now in jdk18 fails to start unless we specifically allow or set a SecurityManager.
This update to the launcher makefile adds JAVA_ARGS to permit a SecurityManager.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279007](https://bugs.openjdk.java.net/browse/JDK-8279007): jstatd fails to start because SecurityManager is disabled


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to eaf7ddf66ee4d14c65935432ee5974249fdc95ab
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Sean Mullan](https://openjdk.java.net/census#mullan) (@seanjmullan - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/53.diff">https://git.openjdk.java.net/jdk18/pull/53.diff</a>

</details>
