### PR TITLE
8278472: Invalid value set to CANDIDATEFORM structure

### DIFF
--- a/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
+++ b/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp
@@ -3917,11 +3917,11 @@ void AwtComponent::SetCandidateWindow(int iCandType, int x, int y)
     HIMC hIMC = ImmGetContext(hwnd);
     if (hIMC) {
         CANDIDATEFORM cf;
-        cf.dwStyle = CFS_POINT;
+        cf.dwStyle = CFS_CANDIDATEPOS;
         ImmGetCandidateWindow(hIMC, 0, &cf);
         if (x != cf.ptCurrentPos.x || y != cf.ptCurrentPos.y) {
             cf.dwIndex = iCandType;
-            cf.dwStyle = CFS_POINT;
+            cf.dwStyle = CFS_CANDIDATEPOS;
             cf.ptCurrentPos = {x, y};
             cf.rcArea = {0, 0, 0, 0};
             ImmSetCandidateWindow(hIMC, &cf);


### PR DESCRIPTION
According to the Windows API reference, `dwStyle` of [`CANDIDATEFORM`](https://docs.microsoft.com/en-us/windows/win32/api/imm/ns-imm-candidateform) structure should be set to `CFS_CANDIDATEPOS` or `CFS_EXCLUDE`. So, `CFS_POINT` is wrong here.

There are two instances in `AwtComponent::SetCandidateWindow` in [`awt_Component.cpp`](https://github.com/openjdk/jdk/blob/f90425a1cbbc686045c87086af586e62f05f6c49/src/java.desktop/windows/native/libawt/windows/awt_Component.cpp#L3914) where the incorrect value is used.

I've created the PR for jdk18 as it's a low-risk fix. If it's inappropriate at this time, I'll open the PR for mainline jdk.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278472](https://bugs.openjdk.java.net/browse/JDK-8278472): Invalid value set to CANDIDATEFORM structure


### Reviewers
 * [Naoto Sato](https://openjdk.java.net/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/54.diff">https://git.openjdk.java.net/jdk18/pull/54.diff</a>

</details>
