### PR TITLE
8278087: Deserialization filter and filter factory property error reporting under specified

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -384,6 +384,8 @@ public class ObjectInputStream
      * <p>The constructor initializes the deserialization filter to the filter returned
      * by invoking the {@link Config#getSerialFilterFactory()} with {@code null} for the current filter
      * and the {@linkplain Config#getSerialFilter() static JVM-wide filter} for the requested filter.
+     * If the serial filter or serial filter factory properties are invalid
+     * an {@link IllegalStateException} is thrown.
      *
      * <p>If a security manager is installed, this constructor will check for
      * the "enableSubclassImplementation" SerializablePermission when invoked
@@ -396,6 +398,8 @@ public class ObjectInputStream
      * @throws  IOException if an I/O error occurs while reading stream header
      * @throws  SecurityException if untrusted subclass illegally overrides
      *          security-sensitive methods
+     * @throws  IllegalStateException if the initialization of {@link ObjectInputFilter.Config}
+     *          fails due to invalid serial filter or serial filter factory properties.
      * @throws  NullPointerException if {@code in} is {@code null}
      * @see     ObjectInputStream#ObjectInputStream()
      * @see     ObjectInputStream#readFields()
@@ -421,6 +425,8 @@ public class ObjectInputStream
      * <p>The constructor initializes the deserialization filter to the filter returned
      * by invoking the {@link Config#getSerialFilterFactory()} with {@code null} for the current filter
      * and the {@linkplain Config#getSerialFilter() static JVM-wide filter} for the requested filter.
+     * If the serial filter or serial filter factory properties are invalid
+     * an {@link IllegalStateException} is thrown.
      *
      * <p>If there is a security manager installed, this method first calls the
      * security manager's {@code checkPermission} method with the
@@ -431,6 +437,8 @@ public class ObjectInputStream
      *          {@code checkPermission} method denies enabling
      *          subclassing.
      * @throws  IOException if an I/O error occurs while creating this stream
+     * @throws  IllegalStateException if the initialization of {@link ObjectInputFilter.Config}
+     *      fails due to invalid serial filter or serial filter factory properties.
      * @see SecurityManager#checkPermission
      * @see java.io.SerializablePermission
      */

--- a/test/jdk/java/io/Serializable/serialFilter/SerialFactoryFaults.java
+++ b/test/jdk/java/io/Serializable/serialFilter/SerialFactoryFaults.java
@@ -22,10 +22,14 @@
  */
 
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.ObjectInputFilter;
 import java.io.ObjectInputFilter.Config;
+import java.io.ObjectInputStream;
 import java.util.function.BinaryOperator;
 
 /* @test
@@ -39,33 +43,47 @@ import java.util.function.BinaryOperator;
 @Test
 public class SerialFactoryFaults {
 
+    // Sample the serial factory class name
+    private static final String factoryName = System.getProperty("jdk.serialFilterFactory");
+
     static {
         // Enable logging
         System.setProperty("java.util.logging.config.file",
                 System.getProperty("test.src", ".") + "/logging.properties");
     }
 
-    public void initFaultTest() {
-        String factoryName = System.getProperty("jdk.serialFilterFactory");
-        ExceptionInInitializerError ex = Assert.expectThrows(ExceptionInInitializerError.class,
-                () -> Config.getSerialFilterFactory());
-        Throwable cause = ex.getCause();
+    @DataProvider(name = "MethodsToCall")
+    private Object[][] cases() {
+        return new Object[][] {
+                {"getSerialFilterFactory", (Assert.ThrowingRunnable) () -> Config.getSerialFilterFactory()},
+                {"setSerialFilterFactory", (Assert.ThrowingRunnable) () -> Config.setSerialFilterFactory(new NoopFactory())},
+                {"new ObjectInputStream(is)", (Assert.ThrowingRunnable) () -> new ObjectInputStream(new ByteArrayInputStream(new byte[0]))},
+                {"new OISSubclass()", (Assert.ThrowingRunnable) () -> new OISSubclass()},
+        };
+    }
+
+    /**
+     * Test each method that should throw IllegalStateException based on
+     * the invalid arguments it was launched with.
+     */
+    @Test(dataProvider = "MethodsToCall")
+    public void initFaultTest(String name, Assert.ThrowingRunnable runnable) {
+        IllegalStateException ex = Assert.expectThrows(IllegalStateException.class,
+                runnable);
+        final String msg = ex.getMessage();
 
         if (factoryName.equals("ForcedError_NoSuchClass")) {
-            Assert.assertEquals(cause.getClass(),
-                    ClassNotFoundException.class, "wrong exception");
+            Assert.assertEquals(msg,
+                    "invalid jdk.serialFilterFactory: ForcedError_NoSuchClass: java.lang.ClassNotFoundException: ForcedError_NoSuchClass", "wrong exception");
         } else if (factoryName.equals("SerialFactoryFaults$NoPublicConstructor")) {
-            Assert.assertEquals(cause.getClass(),
-                    NoSuchMethodException.class, "wrong exception");
+            Assert.assertEquals(msg,
+                    "invalid jdk.serialFilterFactory: SerialFactoryFaults$NoPublicConstructor: java.lang.NoSuchMethodException: SerialFactoryFaults$NoPublicConstructor.<init>()", "wrong exception");
         } else if (factoryName.equals("SerialFactoryFaults$ConstructorThrows")) {
-            Assert.assertEquals(cause.getClass(),
-                    IllegalStateException.class, "wrong exception");
+            Assert.assertEquals(msg,
+                    "invalid jdk.serialFilterFactory: SerialFactoryFaults$ConstructorThrows: java.lang.RuntimeException: constructor throwing a runtime exception", "wrong exception");
         } else if (factoryName.equals("SerialFactoryFaults$FactorySetsFactory")) {
-            Assert.assertEquals(cause.getClass(),
-                    IllegalStateException.class, "wrong exception");
-            Assert.assertEquals(cause.getMessage(),
-                    "Cannot replace filter factory: initialization incomplete",
-                    "wrong message");
+            Assert.assertEquals(msg,
+                    "invalid jdk.serialFilterFactory: SerialFactoryFaults$FactorySetsFactory: java.lang.IllegalStateException: Serial filter factory initialization incomplete", "wrong exception");
         } else {
             Assert.fail("No test for filter factory: " + factoryName);
         }
@@ -90,7 +108,7 @@ public class SerialFactoryFaults {
     public static final class ConstructorThrows
             implements BinaryOperator<ObjectInputFilter> {
         public ConstructorThrows() {
-            throw new IllegalStateException("SerialFactoryFaults$ConstructorThrows");
+            throw new RuntimeException("constructor throwing a runtime exception");
         }
 
         public ObjectInputFilter apply(ObjectInputFilter curr, ObjectInputFilter next) {
@@ -109,6 +127,23 @@ public class SerialFactoryFaults {
 
         public ObjectInputFilter apply(ObjectInputFilter curr, ObjectInputFilter next) {
             throw new RuntimeException("NYI");
+        }
+    }
+
+    public static final class NoopFactory implements BinaryOperator<ObjectInputFilter> {
+        public NoopFactory() {}
+
+        public ObjectInputFilter apply(ObjectInputFilter curr, ObjectInputFilter next) {
+            throw new RuntimeException("NYI");
+        }
+    }
+
+    /**
+     * Subclass of ObjectInputStream to test subclassing constructor.
+     */
+    private static class OISSubclass extends ObjectInputStream {
+
+        protected OISSubclass() throws IOException {
         }
     }
 


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8278087](https://bugs.openjdk.java.net/browse/JDK-8278087): Deserialization filter and filter factory property error reporting under specified
 * [JDK-8278088](https://bugs.openjdk.java.net/browse/JDK-8278088): Deserialization filter and filter factory property error reporting under specified (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/55.diff">https://git.openjdk.java.net/jdk18/pull/55.diff</a>

</details>
