### PR TITLE
8278044: ObjectInputStream methods invoking the OIF.CFG.getSerialFilterFactory() silent about error cases.

### DIFF
--- a/src/java.base/share/classes/java/io/ObjectInputStream.java
+++ b/src/java.base/share/classes/java/io/ObjectInputStream.java
@@ -382,10 +382,13 @@ public class ObjectInputStream
      * has written and flushed the header.
      *
      * <p>The constructor initializes the deserialization filter to the filter returned
-     * by invoking the {@link Config#getSerialFilterFactory()} with {@code null} for the current filter
+     * by invoking the serial filter factory returned from {@link Config#getSerialFilterFactory()}
+     * with {@code null} for the current filter
      * and the {@linkplain Config#getSerialFilter() static JVM-wide filter} for the requested filter.
      * If the serial filter or serial filter factory properties are invalid
      * an {@link IllegalStateException} is thrown.
+     * When the filter factory {@code apply} method is invoked it may throw a runtime exception
+     * preventing the {@code ObjectInputStream} from being constructed.
      *
      * <p>If a security manager is installed, this constructor will check for
      * the "enableSubclassImplementation" SerializablePermission when invoked
@@ -423,10 +426,13 @@ public class ObjectInputStream
      * implementation of ObjectInputStream.
      *
      * <p>The constructor initializes the deserialization filter to the filter returned
-     * by invoking the {@link Config#getSerialFilterFactory()} with {@code null} for the current filter
+     * by invoking the serial filter factory returned from {@link Config#getSerialFilterFactory()}
+     * with {@code null} for the current filter
      * and the {@linkplain Config#getSerialFilter() static JVM-wide filter} for the requested filter.
      * If the serial filter or serial filter factory properties are invalid
      * an {@link IllegalStateException} is thrown.
+     * When the filter factory {@code apply} method is invoked it may throw a runtime exception
+     * preventing the {@code ObjectInputStream} from being constructed.
      *
      * <p>If there is a security manager installed, this method first calls the
      * security manager's {@code checkPermission} method with the


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8278044](https://bugs.openjdk.java.net/browse/JDK-8278044): ObjectInputStream methods invoking the OIF.CFG.getSerialFilterFactory() silent about error cases.
 * [JDK-8278238](https://bugs.openjdk.java.net/browse/JDK-8278238): ObjectInputStream methods invoking the OIF.CFG.getSerialFilterFactory() silent about error cases. (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/58.diff">https://git.openjdk.java.net/jdk18/pull/58.diff</a>

</details>
