### PR TITLE
8279074: ProblemList compiler/codecache/jmx/PoolsIndependenceTest.java on macosx-aarch64

### DIFF
--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -71,7 +71,7 @@ compiler/whitebox/ClearMethodStateTest.java 8265360 macosx-aarch64
 compiler/whitebox/EnqueueMethodForCompilationTest.java 8265360 macosx-aarch64
 compiler/whitebox/MakeMethodNotCompilableTest.java 8265360 macosx-aarch64
 
-compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-x64
+compiler/codecache/jmx/PoolsIndependenceTest.java 8264632 macosx-generic
 compiler/codecache/TestStressCodeBuffers.java 8272094 generic-aarch64
 
 


### PR DESCRIPTION
A trivial fix to ProblemList compiler/codecache/jmx/PoolsIndependenceTest.java on macosx-aarch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279074](https://bugs.openjdk.java.net/browse/JDK-8279074): ProblemList compiler/codecache/jmx/PoolsIndependenceTest.java on macosx-aarch64


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/59.diff">https://git.openjdk.java.net/jdk18/pull/59.diff</a>

</details>
