### PR TITLE
8279076: C2: Bad AD file when matching SqrtF with UseSSE=0

### DIFF
--- a/src/hotspot/cpu/x86/x86.ad
+++ b/src/hotspot/cpu/x86/x86.ad
@@ -1601,6 +1601,16 @@ const bool Matcher::match_rule_supported(int opcode) {
         return false;
       }
       break;
+    case Op_SqrtF:
+      if (UseSSE < 1) {
+        return false;
+      }
+      break;
+    case Op_SqrtD:
+      if (UseSSE < 2) {
+        return false;
+      }
+      break;
   }
   return true;  // Match rules are supported by default.
 }

--- a/test/hotspot/jtreg/compiler/c2/TestSqrt.java
+++ b/test/hotspot/jtreg/compiler/c2/TestSqrt.java
@@ -41,7 +41,7 @@ public class TestSqrt {
     static double dstD;
 
     public static void test() {
-        dstF = (float)Math.sqrt((double)dstF);
+        dstF = (float)Math.sqrt((double)srcF);
         dstD = Math.sqrt(srcD);
     }
 

--- a/test/hotspot/jtreg/compiler/c2/TestSqrt.java
+++ b/test/hotspot/jtreg/compiler/c2/TestSqrt.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.c2;
+
+/*
+ * @test
+ * @bug 8279076
+ * @summary SqrtD/SqrtF should be matched only on supported platforms
+ * @requires vm.debug
+ *
+ * @run main/othervm -XX:-TieredCompilation -Xcomp
+ *                   -XX:CompileOnly=compiler/c2/TestSqrt
+ *                   -XX:CompileOnly=java/lang/Math
+ *                   compiler.c2.TestSqrt
+ */
+public class TestSqrt {
+    static float srcF = 42.0f;
+    static double srcD = 42.0d;
+    static float dstF;
+    static double dstD;
+
+    public static void test() {
+        dstF = (float)Math.sqrt((double)dstF);
+        dstD = Math.sqrt(srcD);
+    }
+
+    public static void main(String args[]) {
+        for (int i = 0; i < 20_000; i++) {
+            test();
+        }
+    }
+}
+


### PR DESCRIPTION
See the reproducer and the analysis in the bug. 

The fix is simple: `Matcher::match_rule_supported` should handle the predicates for current `SqrtF` and `SqrtD` match rules.

Additional testing:
 - [x] Linux x86_32 `-XX:UseAVX=0 -XX:UseSSE=0`, new test now passes
 - [x] Linux x86_32 `-XX:UseAVX=0 -XX:UseSSE=1`, new test passes
 - [x] Linux x86_32 `-XX:UseAVX=0 -XX:UseSSE=2`, new test passes
 - [x] Linux x86_32 `-XX:UseAVX=0 -XX:UseSSE=0`, `jdk/incubator/vector/` now passes
 - [x] Linux x86_32 `-XX:UseAVX=0 -XX:UseSSE=1`, `jdk/incubator/vector/` passes
 - [x] Linux x86_32 `-XX:UseAVX=0 -XX:UseSSE=2`, `jdk/incubator/vector/` passes (some unrelated failures)
 - [x] Linux x86_64, new test passes

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279076](https://bugs.openjdk.java.net/browse/JDK-8279076): C2: Bad AD file when matching SqrtF with UseSSE=0


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Sandhya Viswanathan](https://openjdk.java.net/census#sviswanathan) (@sviswa7 - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/60.diff">https://git.openjdk.java.net/jdk18/pull/60.diff</a>

</details>
