### PR TITLE
8271447: java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/management/ChunkFilename.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/management/ChunkFilename.java
@@ -88,7 +88,7 @@ public final class ChunkFilename {
        StringBuilder sb = new StringBuilder();
        sb.append(filename);
        sb.append('_');
-       if (counter < 10) { // chronological sorted 
+       if (counter < 10) { // chronological sorted
            sb.append('0');
        }
        sb.append(counter);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/management/ChunkFilename.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/management/ChunkFilename.java
@@ -74,7 +74,7 @@ public final class ChunkFilename {
 
        // If more than one file per second
        while (counter < MAX_CHUNK_NAMES) {
-           String extendedName = String.format("%s_%02d%s", filename, counter, FILE_EXTENSION);
+           String extendedName = makeExtendedName(filename, counter);
            p = directory.resolve(extendedName);
            counter++;
            if (!fileAcess.exists(p)) {
@@ -82,5 +82,17 @@ public final class ChunkFilename {
            }
        }
        throw new IOException("Unable to find unused filename after " + counter + " attempts");
+   }
+
+   private String makeExtendedName(String filename, int counter) {
+       StringBuilder sb = new StringBuilder();
+       sb.append(filename);
+       sb.append('_');
+       if (counter < 10) { // chronological sorted 
+           sb.append('0');
+       }
+       sb.append(counter);
+       sb.append(FILE_EXTENSION);
+       return sb.toString();
    }
 }


### PR DESCRIPTION
Hi,

On arabic locales, the filename of a repository file may become invalid. 

Fix is to format the filename using a StringBuilder instead of using String.format("%s_%02d%s", filename, counter, FILE_EXTENSION). A similar problem exists when using 'jfr disassemble <recording-file>', but it is much more unlikely to happen, so it will be fixed separately for JDK 19. 

Testing: jdk/jdk/jfr

Thanks 
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8271447](https://bugs.openjdk.java.net/browse/JDK-8271447): java.nio.file.InvalidPathException: Malformed input or input contains unmappable characters


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/64.diff">https://git.openjdk.java.net/jdk18/pull/64.diff</a>

</details>
