### PR TITLE
8278125: Some preallocated OOMEs are missing stack trace

### DIFF
--- a/src/hotspot/share/memory/universe.cpp
+++ b/src/hotspot/share/memory/universe.cpp
@@ -110,6 +110,11 @@ OopHandle Universe::_delayed_stack_overflow_error_message;
 OopHandle Universe::_preallocated_out_of_memory_error_array;
 volatile jint Universe::_preallocated_out_of_memory_error_avail_count = 0;
 
+// Message details for OOME objects, preallocate these objects since they could be
+// used when throwing OOME, we should try to avoid further allocation in such case
+OopHandle Universe::_msg_metaspace;
+OopHandle Universe::_msg_class_metaspace;
+
 OopHandle Universe::_null_ptr_exception_instance;
 OopHandle Universe::_arithmetic_exception_instance;
 OopHandle Universe::_virtual_machine_error_instance;
@@ -540,7 +545,6 @@ static void reinitialize_itables() {
   ClassLoaderDataGraph::classes_do(&cl);
 }
 
-
 bool Universe::on_page_boundary(void* addr) {
   return is_aligned(addr, os::vm_page_size());
 }
@@ -640,6 +644,14 @@ oop Universe::gen_out_of_memory_error(oop default_err) {
   }
 }
 
+bool Universe::is_out_of_memory_error_metaspace(oop ex_obj) {
+  return java_lang_Throwable::message(ex_obj) == _msg_metaspace.resolve();
+}
+
+bool Universe::is_out_of_memory_error_class_metaspace(oop ex_obj) {
+  return java_lang_Throwable::message(ex_obj) == _msg_class_metaspace.resolve();
+}
+
 // Setup preallocated OutOfMemoryError errors
 void Universe::create_preallocated_out_of_memory_errors(TRAPS) {
   InstanceKlass* ik = vmClasses::OutOfMemoryError_klass();
@@ -659,9 +671,11 @@ void Universe::create_preallocated_out_of_memory_errors(TRAPS) {
   java_lang_Throwable::set_message(oom_array->obj_at(_oom_c_heap), msg());
 
   msg = java_lang_String::create_from_str("Metaspace", CHECK);
+  _msg_metaspace = OopHandle(vm_global(), msg());
   java_lang_Throwable::set_message(oom_array->obj_at(_oom_metaspace), msg());
 
   msg = java_lang_String::create_from_str("Compressed class space", CHECK);
+  _msg_class_metaspace = OopHandle(vm_global(), msg());
   java_lang_Throwable::set_message(oom_array->obj_at(_oom_class_metaspace), msg());
 
   msg = java_lang_String::create_from_str("Requested array size exceeds VM limit", CHECK);

--- a/src/hotspot/share/memory/universe.hpp
+++ b/src/hotspot/share/memory/universe.hpp
@@ -132,6 +132,10 @@ class Universe: AllStatic {
   // number of preallocated error objects available for use
   static volatile jint _preallocated_out_of_memory_error_avail_count;
 
+  // preallocated message detail strings for error objects
+  static OopHandle _msg_metaspace;
+  static OopHandle _msg_class_metaspace;
+
   static OopHandle    _null_ptr_exception_instance;   // preallocated exception object
   static OopHandle    _arithmetic_exception_instance; // preallocated exception object
   static OopHandle    _virtual_machine_error_instance; // preallocated exception object
@@ -293,6 +297,10 @@ class Universe: AllStatic {
   // Throw default _out_of_memory_error_retry object as it will never propagate out of the VM
   static oop out_of_memory_error_retry();
   static oop delayed_stack_overflow_error_message();
+
+  // If it's a certain type of OOME object
+  static bool is_out_of_memory_error_metaspace(oop ex_obj);
+  static bool is_out_of_memory_error_class_metaspace(oop ex_obj);
 
   // The particular choice of collected heap.
   static CollectedHeap* heap() { return _collectedHeap; }

--- a/src/hotspot/share/utilities/exceptions.cpp
+++ b/src/hotspot/share/utilities/exceptions.cpp
@@ -461,9 +461,9 @@ volatile int Exceptions::_out_of_memory_error_metaspace_errors = 0;
 volatile int Exceptions::_out_of_memory_error_class_metaspace_errors = 0;
 
 void Exceptions::count_out_of_memory_exceptions(Handle exception) {
-  if (exception() == Universe::out_of_memory_error_metaspace()) {
+  if (Universe::is_out_of_memory_error_metaspace(exception())) {
      Atomic::inc(&_out_of_memory_error_metaspace_errors, memory_order_relaxed);
-  } else if (exception() == Universe::out_of_memory_error_class_metaspace()) {
+  } else if (Universe::is_out_of_memory_error_metaspace(exception())) {
      Atomic::inc(&_out_of_memory_error_class_metaspace_errors, memory_order_relaxed);
   } else {
      // everything else reported as java heap OOM

--- a/test/hotspot/jtreg/runtime/ErrorHandling/GenOutOfMemoryError.java
+++ b/test/hotspot/jtreg/runtime/ErrorHandling/GenOutOfMemoryError.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+
+/*
+ * @test
+ * @bug 8278125
+ * @summary Test if OOME has proper stacktrace
+ * @library /test/lib
+ * @run main/othervm -Xmx100m -Xms100m GenOutOfMemoryError
+ */
+
+import jdk.test.lib.Asserts;
+
+public class GenOutOfMemoryError {
+    private static int OOME_HAS_STACK_CNT = 0;
+
+    private void badMethod(int n){
+        try {
+            System.out.format("bad method was invoked %n", n);
+            // Try to allocate an array the same size as the heap - it will throw OOME without
+            // actually consuming available memory.
+            Integer[] array = new Integer[1000 * 1000 * 100];
+            array.hashCode();
+        } catch (Throwable t){
+            StackTraceElement[] traces  = t.getStackTrace();
+            if (traces.length != 0) {
+                OOME_HAS_STACK_CNT++;
+            }
+            t.printStackTrace();
+        }
+    }
+
+    public static void main(String[] args) {
+        GenOutOfMemoryError genOutOfMemoryError = new GenOutOfMemoryError();
+
+        for (int i = 0; i < 7; i++) {
+            genOutOfMemoryError.badMethod(i + 1);
+        }
+        Asserts.assertTrue(4/*PreallocatedOutOfMemoryErrorCount defaults to 4*/ == OOME_HAS_STACK_CNT, "Some OOMEs do not have stacktraces");
+    }
+}


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278125](https://bugs.openjdk.java.net/browse/JDK-8278125): Some preallocated OOMEs are missing stack trace


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/67.diff">https://git.openjdk.java.net/jdk18/pull/67.diff</a>

</details>
