### PR TITLE
8268297: jdk/jfr/api/consumer/streaming/TestLatestEvent.java times out

### DIFF
--- a/src/hotspot/share/jfr/recorder/repository/jfrChunk.cpp
+++ b/src/hotspot/share/jfr/recorder/repository/jfrChunk.cpp
@@ -47,6 +47,8 @@ static jlong nanos_now() {
   const jlong now = seconds * 1000000000 + nanos;
   if (now > last) {
     last = now;
+  } else {
+    ++last;
   }
   return last;
 }

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -824,7 +824,6 @@ jdk/jfr/event/compiler/TestCodeSweeper.java                     8225209 generic-
 jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-all
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
-jdk/jfr/api/consumer/streaming/TestLatestEvent.java             8268297 windows-x64
 jdk/jfr/event/oldobject/TestLargeRootSet.java                   8276333 macosx-x64,windows-x64
 
 ############################################################################


### PR DESCRIPTION
Hi,

Could I have a review of a fix that prevents a recording stream from dropping events/chunks. 

This occurs when rotation happens quickly, as in TestLatestEvent.java, and the clock is not making progress, on Windows sometimes. The result is a chunk header with duration 0 ns, meaning there could be two chunks with the same start timestamp, which confuses the RecordingStream when determining iteration order.

The fix is to always increase the elapsed time by at least 1 ns. There were similar code prior to JDK 17, but it was removed because a mechanism was added in Java that makes sure a chunk always gets a unique Instant.now() timestamp. Unfortunately, that timestamp does not always correlate with what the JVM writes, which leads to intermittent failures in 2-4% of the time. 

I also updated the test, so it can provide better information in case of new failures.

Testing:  
test/jdk/jdk/jfr/api/consumer/streaming/TestLatestEvent.java 600 times without failure on Windows
test/jdk/jdk/jfr/ 6 times without failure on Mac, Linux and Windows.

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8268297](https://bugs.openjdk.java.net/browse/JDK-8268297): jdk/jfr/api/consumer/streaming/TestLatestEvent.java times out


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/68.diff">https://git.openjdk.java.net/jdk18/pull/68.diff</a>

</details>
