### PR TITLE
8279195: Document the -XX:+NeverActAsServerClassMachine flag

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -1541,6 +1541,31 @@ and its committed regions.
 .RE
 .RE
 .TP
+.B \f[CB]\-XX:+NeverActAsServerClassMachine\f[R]
+Enable the "Client VM emulation" mode which only uses the C1 JIT
+compiler, a 32Mb CodeCache and the Serial GC.
+The maximum amount of memory that the JVM may use (controlled by the
+\f[CB]\-XX:MaxRAM=n\f[R] flag) is set to 1GB by default.
+The string "emulated\-client" is added to the JVM version string.
+.RS
+.PP
+By default the flag is set to \f[CB]true\f[R] only on Windows in 32\-bit
+mode and \f[CB]false\f[R] in all other cases.
+.PP
+The "Client VM emulation" mode will not be enabled if any of the
+following flags are used on the command line:
+.IP
+.nf
+\f[CB]
+\-XX:{+|\-}TieredCompilation
+\-XX:CompilationMode=mode
+\-XX:TieredStopAtLevel=n
+\-XX:{+|\-}EnableJVMCI
+\-XX:{+|\-}UseJVMCICompiler
+\f[R]
+.fi
+.RE
+.TP
 .B \f[CB]\-XX:ObjectAlignmentInBytes=\f[R]\f[I]alignment\f[R]
 Sets the memory alignment of Java objects (in bytes).
 By default, the value is set to 8 bytes.


### PR DESCRIPTION
This product flag provides a way to emulate the old "Client VM" but has never been documented in the java command reference (aka manpage). It should be documented.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279195](https://bugs.openjdk.java.net/browse/JDK-8279195): Document the -XX:+NeverActAsServerClassMachine flag


### Reviewers
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/71/head:pull/71` \
`$ git checkout pull/71`

Update a local copy of the PR: \
`$ git checkout pull/71` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/71/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 71`

View PR using the GUI difftool: \
`$ git pr show -t 71`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/71.diff">https://git.openjdk.java.net/jdk18/pull/71.diff</a>

</details>
