### PR TITLE
8279227: Access Bridge: Wrong frame position and hit test result on HiDPI display

### DIFF
--- a/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
+++ b/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
@@ -478,6 +478,19 @@ public final class AccessBridge {
         if (parent == null) {
             return null;
         }
+        Point location = new Point(x, y);
+        InvocationUtils.invokeAndWait(new Callable<Void>() {
+            @Override
+            public Void call() throws Exception {
+                AffineTransform at = getTransformFromContext(parent);
+                if (at != null) {
+                    location.setLocation((int) (location.x / at.getScaleX()), (int) (location.y / at.getScaleY()));
+                }
+                return null;
+            }
+        }, parent);
+        x = location.x;
+        y = location.y;
         if (windowHandleToContextMap != null &&
             windowHandleToContextMap.containsValue(getRootAccessibleContext(parent))) {
             // Path for applications that register their top-level
@@ -1593,6 +1606,14 @@ public final class AccessBridge {
                             if (p != null) {
                                 r.x = p.x;
                                 r.y = p.y;
+
+                                AffineTransform at = getTransformFromContext(ac);
+                                if (at != null) {
+                                    r.x = (int) Math.floor(r.x * at.getScaleX());
+                                    r.y = (int) Math.floor(r.y * at.getScaleY());
+                                    r.width = (int) Math.ceil(r.width * at.getScaleX());
+                                    r.height = (int) Math.ceil(r.height * at.getScaleY());
+                                }
                                 return r;
                             }
                         } catch (Exception e) {
@@ -1735,6 +1756,20 @@ public final class AccessBridge {
         }, ac);
     }
 
+    /**
+     * return the screen coordinates transform from an AccessibleContext
+     */
+    private AffineTransform getTransformFromContext(final AccessibleContext ac) {
+        AccessibleComponent acomp = ac.getAccessibleComponent();
+        if (acomp != null) {
+            FontMetrics fm = acomp.getFontMetrics(acomp.getFont());
+            if (fm != null) {
+                return fm.getFontRenderContext().getTransform();
+            }
+        }
+
+        return null;
+    }
     /* ===== AccessibleText methods ===== */
 
     /**
@@ -2253,6 +2288,13 @@ public final class AccessBridge {
                     if (at != null) {
                         Rectangle rect = at.getCharacterBounds(index);
                         if (rect != null) {
+                            AffineTransform transform = getTransformFromContext(ac);
+                            if (transform != null) {
+                                rect.x = (int) Math.floor(rect.x * transform.getScaleX());
+                                rect.y = (int) Math.floor(rect.y * transform.getScaleY());
+                                rect.width = (int) Math.ceil(rect.width * transform.getScaleX());
+                                rect.height = (int) Math.ceil(rect.height * transform.getScaleY());
+                            }
                             String s = at.getAtIndex(AccessibleText.CHARACTER, index);
                             if (s != null && s.equals("\n")) {
                                 rect.width = 0;

--- a/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
+++ b/src/jdk.accessibility/windows/classes/com/sun/java/accessibility/internal/AccessBridge.java
@@ -27,6 +27,7 @@ package com.sun.java.accessibility.internal;
 
 import java.awt.*;
 import java.awt.event.*;
+import java.awt.geom.AffineTransform;
 import java.util.*;
 import java.lang.*;
 import java.lang.reflect.*;


### PR DESCRIPTION
Perform scaling while converting sizes and coordinates to provide correct positions of accessible elements on HiDPI screen and make hit-test work properly. It uses FontRenderContext to receive display scale without API changes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279227](https://bugs.openjdk.java.net/browse/JDK-8279227): Access Bridge: Wrong frame position and hit test result on HiDPI display


### Reviewers
 * [Anton Tarasov](https://openjdk.java.net/census#ant) (@forantar - **Reviewer**) ⚠️ Review applies to 4ad508fee6fcdb84ea95223aba57d629cc0e4a06
 * [Alexander Zuev](https://openjdk.java.net/census#kizune) (@azuev-java - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.java.net/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/72/head:pull/72` \
`$ git checkout pull/72`

Update a local copy of the PR: \
`$ git checkout pull/72` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/72/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 72`

View PR using the GUI difftool: \
`$ git pr show -t 72`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/72.diff">https://git.openjdk.java.net/jdk18/pull/72.diff</a>

</details>
