### PR TITLE
8279379: GHA: Print tests that are in error

### DIFF
--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -341,6 +341,7 @@ jobs:
         run: >
           if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
             cat build/*/test-results/*/text/newfailures.txt ;
+            cat build/*/test-results/*/text/other_errors.txt ;
             exit 1 ;
           fi
 
@@ -807,6 +808,7 @@ jobs:
         run: >
           if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
             cat build/*/test-results/*/text/newfailures.txt ;
+            cat build/*/test-results/*/text/other_errors.txt ;
             exit 1 ;
           fi
 
@@ -1218,6 +1220,7 @@ jobs:
         run: >
           if ((Get-ChildItem -Path build\*\test-results\test-summary.txt -Recurse | Select-String -Pattern "TEST SUCCESS" ).Count -eq 0) {
             Get-Content -Path build\*\test-results\*\*\newfailures.txt ;
+            Get-Content -Path build\*\test-results\*\*\other_errors.txt ;
             exit 1
           }
 
@@ -1611,6 +1614,7 @@ jobs:
         run: >
           if ! grep --include=test-summary.txt -lqr build/*/test-results -e "TEST SUCCESS" ; then
             cat build/*/test-results/*/text/newfailures.txt ;
+            cat build/*/test-results/*/text/other_errors.txt ;
             exit 1 ;
           fi
 


### PR DESCRIPTION
Current GHA workflow only prints `newfailures.txt` when tests fail. But the tests can also "ERROR" out. In which case, we want to print `other_errors.txt` as well. In current mainline GHA, we have a x86_32 langtools_tier1 failure like this:

```
==============================
Test summary
==============================
   TEST                                              TOTAL  PASS  FAIL ERROR   
>> jtreg:test/langtools:tier1                         4282  4281     0     1 <<
==============================
TEST FAILURE

# newfailures.txt
<empty>

# other_errors.txt
jdk/javadoc/doclet/testLinkPlatform/TestLinkPlatform.java
```

I would like to get it in JDK 18 as well, to make GHA better during stabilization.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279379](https://bugs.openjdk.java.net/browse/JDK-8279379): GHA: Print tests that are in error


### Reviewers
 * [Erik Joelsson](https://openjdk.java.net/census#erikj) (@erikj79 - **Reviewer**)
 * [Christoph Langer](https://openjdk.java.net/census#clanger) (@RealCLanger - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/75/head:pull/75` \
`$ git checkout pull/75`

Update a local copy of the PR: \
`$ git checkout pull/75` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/75/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 75`

View PR using the GUI difftool: \
`$ git pr show -t 75`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/75.diff">https://git.openjdk.java.net/jdk18/pull/75.diff</a>

</details>
