### PR TITLE
8265317: [vector] assert(payload->is_object()) failed: expected 'object' value for scalar-replaced boxed vector but got: NULL

### DIFF
--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/prims/vectorSupport.cpp
+++ b/src/hotspot/share/prims/vectorSupport.cpp
@@ -172,17 +172,17 @@ Handle VectorSupport::allocate_vector_payload(InstanceKlass* ik, frame* fr, Regi
       return allocate_vector_payload_helper(ik, fr, reg_map, location, THREAD); // safepoint
     }
 #ifdef ASSERT
-    // Other payload values are: 'oop' type location and Scalar-replaced boxed vector representation.
+    // Other payload values are: 'oop' type location and scalar-replaced boxed vector representation.
     // They will be processed in Deoptimization::reassign_fields() after all objects are reallocated.
     else {
       Location::Type loc_type = location.type();
       assert(loc_type == Location::oop || loc_type == Location::narrowoop,
              "expected 'oop'(%d) or 'narrowoop'(%d) types location but got: %d", Location::oop, Location::narrowoop, loc_type);
     }
-  } else if (!payload->is_object()) {
+  } else if (!payload->is_object() && !payload->is_constant_oop()) {
     stringStream ss;
     payload->print_on(&ss);
-    assert(payload->is_object(), "expected 'object' value for scalar-replaced boxed vector but got: %s", ss.as_string());
+    assert(false, "expected 'object' value for scalar-replaced boxed vector but got: %s", ss.as_string());
 #endif
   }
   return Handle(THREAD, nullptr);


### PR DESCRIPTION
The assertion is too strong. it doesn't take into account the case of a scalar-replaced instance with a constant field (null in this particular case). 

Proposed fix relaxes the check. 

Testing: 
  * failing tests w/ -XX:+DeoptimizeALot
  * hs-tier2 w/ -XX:+DeoptimizeALot
  * hs-tier1 - hs-tier5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8265317](https://bugs.openjdk.java.net/browse/JDK-8265317): [vector] assert(payload->is_object()) failed: expected 'object' value for scalar-replaced boxed vector but got: NULL


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**) ⚠️ Review applies to 59d23d4084e02e94ab2b74d656fcb639dda29e82
 * [Tobias Hartmann](https://openjdk.java.net/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/76.diff">https://git.openjdk.java.net/jdk18/pull/76.diff</a>

</details>
