### PR TITLE
8275830: C2: Receiver downcast is missing when inlining through method handle linkers

### DIFF
--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/share/opto/doCall.cpp
+++ b/src/hotspot/share/opto/doCall.cpp
@@ -67,13 +67,17 @@ CallGenerator* Compile::call_generator(ciMethod* callee, int vtable_index, bool 
                                        JVMState* jvms, bool allow_inline,
                                        float prof_factor, ciKlass* speculative_receiver_type,
                                        bool allow_intrinsics) {
-  ciMethod*       caller   = jvms->method();
-  int             bci      = jvms->bci();
-  Bytecodes::Code bytecode = caller->java_code_at_bci(bci);
-  guarantee(callee != NULL, "failed method resolution");
+  assert(callee != NULL, "failed method resolution");
+
+  ciMethod*       caller      = jvms->method();
+  int             bci         = jvms->bci();
+  Bytecodes::Code bytecode    = caller->java_code_at_bci(bci);
+  ciMethod*       orig_callee = caller->get_method_at_bci(bci);
 
   const bool is_virtual_or_interface = (bytecode == Bytecodes::_invokevirtual) ||
-                                       (bytecode == Bytecodes::_invokeinterface);
+                                       (bytecode == Bytecodes::_invokeinterface) ||
+                                       (orig_callee->intrinsic_id() == vmIntrinsics::_linkToVirtual) ||
+                                       (orig_callee->intrinsic_id() == vmIntrinsics::_linkToInterface);
 
   // Dtrace currently doesn't work unless all calls are vanilla
   if (env()->dtrace_method_probes()) {

--- a/test/hotspot/jtreg/compiler/cha/AbstractRootMethod.java
+++ b/test/hotspot/jtreg/compiler/cha/AbstractRootMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/cha/AbstractRootMethod.java
+++ b/test/hotspot/jtreg/compiler/cha/AbstractRootMethod.java
@@ -50,12 +50,23 @@
  */
 package compiler.cha;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
 import static compiler.cha.Utils.*;
 
 public class AbstractRootMethod {
     public static void main(String[] args) {
         run(AbstractClass.class);
         run(AbstractInterface.class);
+
+        // Implementation limitation: CHA is not performed by C1 during inlining through MH linkers.
+        if (!sun.hotspot.code.Compiler.isC1Enabled()) {
+            run(AbstractClass.TestMH.class, AbstractClass.class);
+            run(AbstractInterface.TestMH.class, AbstractInterface.class);
+        }
+
+        System.out.println("TEST PASSED");
     }
 
     public static class AbstractClass extends ATest<AbstractClass.C> {
@@ -124,7 +135,21 @@ public class AbstractRootMethod {
             call(new G() { public Object m() { return CORRECT; } }); //  Gn <: G.m <: C.m ABSTRACT
             assertCompiled();
         }
+
+        public static class TestMH extends AbstractClass {
+            static final MethodHandle TEST_MH = findVirtualHelper(C.class, "m", Object.class, MethodHandles.lookup());
+
+            @Override
+            public Object test(C obj) {
+                try {
+                    return TEST_MH.invokeExact(obj); // invokevirtual C.m()
+                } catch (Throwable e) {
+                    throw new InternalError(e);
+                }
+            }
+        }
     }
+
     public static class AbstractInterface extends ATest<AbstractInterface.C> {
         public AbstractInterface() {
             super(C.class, D.class);
@@ -192,6 +217,19 @@ public class AbstractRootMethod {
             call(new C() { public Object m() { return CORRECT; } }); //  Cn.m <: C <: I.m ABSTRACT
             call(new G() { public Object m() { return CORRECT; } }); //  Gn <: G.m <: C <: I.m ABSTRACT
             assertCompiled();
+        }
+
+        public static class TestMH extends AbstractInterface {
+            static final MethodHandle TEST_MH = findVirtualHelper(C.class, "m", Object.class, MethodHandles.lookup());
+
+            @Override
+            public Object test(C obj) {
+                try {
+                    return TEST_MH.invokeExact(obj); // invokevirtual C.m()
+                } catch (Throwable e) {
+                    throw new InternalError(e);
+                }
+            }
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/cha/DefaultRootMethod.java
+++ b/test/hotspot/jtreg/compiler/cha/DefaultRootMethod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/cha/DefaultRootMethod.java
+++ b/test/hotspot/jtreg/compiler/cha/DefaultRootMethod.java
@@ -50,12 +50,22 @@
  */
 package compiler.cha;
 
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
 import static compiler.cha.Utils.*;
 
 public class DefaultRootMethod {
     public static void main(String[] args) {
         run(DefaultRoot.class);
         run(InheritedDefault.class);
+
+        // Implementation limitation: CHA is not performed by C1 during inlining through MH linkers.
+        if (!sun.hotspot.code.Compiler.isC1Enabled()) {
+            run(DefaultRoot.TestMH.class, DefaultRoot.class);
+            run(InheritedDefault.TestMH.class, InheritedDefault.class);
+        }
+
         System.out.println("TEST PASSED");
     }
 
@@ -83,7 +93,7 @@ public class DefaultRootMethod {
         static          class G  extends C { public Object m() { return CORRECT; } }
 
         @Override
-        public Object test(C obj) {
+        public Object test(C obj) throws Throwable {
             return obj.m(); // invokevirtual C.m()
         }
 
@@ -122,6 +132,15 @@ public class DefaultRootMethod {
             call(new G() { public Object m() { return CORRECT; } }); //  Gn <: G.m <: C <: I.m DEFAULT
             assertCompiled();
         }
+
+        public static class TestMH extends DefaultRoot {
+            static final MethodHandle TEST_MH = findVirtualHelper(C.class, "m", Object.class, MethodHandles.lookup());
+
+            @Override
+            public Object test(C obj) throws Throwable {
+                return TEST_MH.invokeExact(obj); // invokevirtual C.m()
+            }
+        }
     }
 
     public static class InheritedDefault extends ATest<InheritedDefault.C> {
@@ -151,7 +170,7 @@ public class DefaultRootMethod {
         static class G extends C implements K { /* inherits K.m DEFAULT */ }
 
         @Override
-        public Object test(C obj) {
+        public Object test(C obj) throws Throwable {
             return obj.m(); // invokevirtual C.m()
         }
 
@@ -189,6 +208,15 @@ public class DefaultRootMethod {
             call(new C() { public Object m() { return CORRECT; } }); //  Cn.m <: C <: I.m DEFAULT
             call(new G() { public Object m() { return CORRECT; } }); //  Gn <: G.m <: C <: I.m DEFAULT
             assertCompiled();
+        }
+
+        public static class TestMH extends InheritedDefault {
+            static final MethodHandle TEST_MH = findVirtualHelper(C.class, "m", Object.class, MethodHandles.lookup());
+
+            @Override
+            public Object test(C obj) throws Throwable {
+                return TEST_MH.invokeExact(obj); // invokevirtual C.m()
+            }
         }
     }
 }

--- a/test/hotspot/jtreg/compiler/cha/Utils.java
+++ b/test/hotspot/jtreg/compiler/cha/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/cha/Utils.java
+++ b/test/hotspot/jtreg/compiler/cha/Utils.java
@@ -34,6 +34,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.concurrent.Callable;
@@ -45,6 +46,7 @@ import static jdk.test.lib.Asserts.assertTrue;
 
 public class Utils {
     public static final Unsafe U = Unsafe.getUnsafe();
+    public static final WhiteBox WB = WhiteBox.getWhiteBox();
 
     interface Test<T> {
         void call(T o);
@@ -99,8 +101,6 @@ public class Utils {
     }
 
     public static abstract class ATest<T> implements Test<T> {
-        public static final WhiteBox WB = WhiteBox.getWhiteBox();
-
         public static final Object CORRECT = new Object();
         public static final Object WRONG   = new Object();
 
@@ -117,7 +117,7 @@ public class Utils {
         }
 
         @DontInline
-        public abstract Object test(T i);
+        public abstract Object test(T i) throws Throwable;
 
         public abstract void checkInvalidReceiver();
 
@@ -132,7 +132,6 @@ public class Utils {
                 }
             }));
         }
-
 
         public void compile(Runnable r) {
             while (!WB.isMethodCompiled(TEST)) {
@@ -161,19 +160,35 @@ public class Utils {
 
         @Override
         public void call(T i) {
-            assertTrue(test(i) != WRONG);
+            try {
+                assertTrue(test(i) != WRONG);
+            } catch (Throwable e) {
+                throw new InternalError(e);
+            }
+        }
+
+        public static <T> T compute(Callable<T> c) {
+            try {
+                return c.call();
+            } catch (Exception e) {
+                throw new Error(e);
+            }
+        }
+
+        public static MethodHandle findVirtualHelper(Class<?> refc, String name, Class<?> returnType, MethodHandles.Lookup lookup) {
+            return compute(() -> lookup.findVirtual(refc, name, MethodType.methodType(returnType)));
         }
     }
 
     @Retention(value = RetentionPolicy.RUNTIME)
     public @interface TestCase {}
 
-    static void run(Class<?> test) {
+    static void run(Class<?> test, Class<?> enclosed) {
         try {
-            for (Method m : test.getDeclaredMethods()) {
+            for (Method m : test.getMethods()) {
                 if (m.isAnnotationPresent(TestCase.class)) {
                     System.out.println(m.toString());
-                    ClassLoader cl = new MyClassLoader(test);
+                    ClassLoader cl = new MyClassLoader(enclosed);
                     Class<?> c = cl.loadClass(test.getName());
                     c.getMethod(m.getName()).invoke(c.getDeclaredConstructor().newInstance());
                 }
@@ -181,6 +196,10 @@ public class Utils {
         } catch (Exception e) {
             throw new Error(e);
         }
+    }
+
+    static void run(Class<?> test) {
+        run(test, test);
     }
 
     static class ObjectToStringHelper {
@@ -303,7 +322,7 @@ public class Utils {
         try {
             r.run();
             throw new AssertionError("Exception not thrown: " + expectedException.getName());
-        } catch(Throwable e) {
+        } catch (Throwable e) {
             if (expectedException == e.getClass()) {
                 // success: proper exception is thrown
             } else {
@@ -317,14 +336,6 @@ public class Utils {
             MethodHandle mh = MethodHandles.identity(Object.class);
             return MethodHandles.explicitCastArguments(mh, mh.type().changeReturnType(cls));
         } catch (Throwable e) {
-            throw new Error(e);
-        }
-    }
-
-    static <T> T compute(Callable<T> c) {
-        try {
-            return c.call();
-        } catch (Exception e) {
             throw new Error(e);
         }
     }


### PR DESCRIPTION
JDK-8268405 introduced receiver downcasts when inlining through virtual calls
when CHA reveals a unique target method under an abstract or default method.
But it handled only cases when invocation is performed using
`invokevirtual`/`invokeinterface` bytecodes and completely omitted `invokedynamic` and
`MethodHandles` cases. 

The fix covers missing cases by checking whether invocation happens through 
corresponding method handle linkers (`MethodHandle.linkToVirtual`/`MethodHandle.linkToInterface`).

Testing: hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8275830](https://bugs.openjdk.java.net/browse/JDK-8275830): C2: Receiver downcast is missing when inlining through method handle linkers


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/77.diff">https://git.openjdk.java.net/jdk18/pull/77.diff</a>

</details>
