### PR TITLE
8278373: JavacTrees.searchMethod finds incorrect match

### DIFF
--- a/test/langtools/tools/javac/doctree/ReferenceTest.java
+++ b/test/langtools/tools/javac/doctree/ReferenceTest.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 7021614
+ * @bug 7021614 8278373
  * @summary extend com.sun.source API to support parsing javadoc comments
  * @summary check references in at-see and {at-link} tags
  * @modules jdk.compiler
@@ -39,19 +39,23 @@ import com.sun.source.doctree.SeeTree;
 import com.sun.source.doctree.TextTree;
 import com.sun.source.util.DocTreePath;
 import com.sun.source.util.DocTreePathScanner;
-import com.sun.source.util.DocTreeScanner;
 import com.sun.source.util.DocTrees;
 import com.sun.source.util.TreePath;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic.Kind;
 
 /**
@@ -174,14 +178,46 @@ public class ReferenceTest extends AbstractProcessor {
             if (label.size() > 0 && label.get(0) instanceof TextTree)
                 expect = ((TextTree) label.get(0)).getBody();
 
-            if (!expect.equalsIgnoreCase(found == null ? "bad" : found.getKind().name())) {
-                error(tree, "Unexpected value found: " + found +", expected: " + expect);
+            if (expect.startsWith("signature:")) {
+                expect = expect.substring("signature:".length());
+
+                String signature = found.getKind().name() + ":" + elementSignature(found);
+
+                if (!expect.equalsIgnoreCase(signature)) {
+                    error(tree, "Unexpected value found: " + signature +", expected: " + expect);
+                }
+            } else {
+                if (!expect.equalsIgnoreCase(found == null ? "bad" : found.getKind().name())) {
+                    error(tree, "Unexpected value found: " + found +", expected: " + expect);
+                }
             }
         }
 
         void error(DocTree tree, String msg) {
             trees.printMessage(Kind.ERROR, msg, tree, dc, path.getCompilationUnit());
         }
+    }
+
+    String elementSignature(Element el) {
+        return switch (el.getKind()) {
+            case METHOD -> elementSignature(el.getEnclosingElement()) + "." + el.getSimpleName() + "(" + executableParamNames((ExecutableElement) el) + ")";
+            case CLASS, INTERFACE -> ((QualifiedNameable) el).getQualifiedName().toString();
+            default -> throw new AssertionError("Unhandled Element kind: " + el.getKind());
+        };
+    }
+
+    String executableParamNames(ExecutableElement ee) {
+        return ee.getParameters()
+                 .stream()
+                 .map(p -> type2Name(p.asType()))
+                 .collect(Collectors.joining(", "));
+    }
+
+    String type2Name(TypeMirror type) {
+        return switch (type.getKind()) {
+            case DECLARED -> elementSignature(((DeclaredType) type).asElement());
+            default -> throw new AssertionError("Unhandled type kind: " + type.getKind());
+        };
     }
 }
 
@@ -199,6 +235,9 @@ public class ReferenceTest extends AbstractProcessor {
  * @see #varargs(int... args)   Method
  * @see #varargs(int[])         Method
  * @see #varargs(int[] args)    Method
+ *
+ * @see #methodSearch(String)   signature:METHOD:ReferenceTestExtras.methodSearch(java.lang.String)
+ * @see #methodSearch(StringBuilder)   signature:METHOD:ReferenceTestExtras.methodSearch(java.lang.CharSequence)
  */
 class ReferenceTestExtras {
     int ReferenceTestExtras;            // field
@@ -214,6 +253,10 @@ class ReferenceTestExtras {
     void m(int i, int j) { }
 
     void varargs(int... args) { }
+
+    void methodSearch(Object o) {}
+    void methodSearch(String s) {}
+    void methodSearch(CharSequence cs) {}
 }
 
 

--- a/test/langtools/tools/javac/doctree/ReferenceTest.java
+++ b/test/langtools/tools/javac/doctree/ReferenceTest.java
@@ -216,6 +216,7 @@ public class ReferenceTest extends AbstractProcessor {
     String type2Name(TypeMirror type) {
         return switch (type.getKind()) {
             case DECLARED -> elementSignature(((DeclaredType) type).asElement());
+            case INT, LONG -> type.toString();
             default -> throw new AssertionError("Unhandled type kind: " + type.getKind());
         };
     }
@@ -238,6 +239,14 @@ public class ReferenceTest extends AbstractProcessor {
  *
  * @see #methodSearch(String)   signature:METHOD:ReferenceTestExtras.methodSearch(java.lang.String)
  * @see #methodSearch(StringBuilder)   signature:METHOD:ReferenceTestExtras.methodSearch(java.lang.CharSequence)
+ * @see #methodSearchPrimitive1(int, int)   signature:METHOD:ReferenceTestExtras.methodSearchPrimitive1(int, int)
+ * @see #methodSearchPrimitive1(long, int)   signature:METHOD:ReferenceTestExtras.methodSearchPrimitive1(long, int)
+ * @see #methodSearchPrimitive1(int, long)   signature:METHOD:ReferenceTestExtras.methodSearchPrimitive1(int, long)
+ * @see #methodSearchPrimitive1(long, long)   signature:METHOD:ReferenceTestExtras.methodSearchPrimitive1(long, long)
+ * @see #methodSearchPrimitive2(int, int)   signature:METHOD:ReferenceTestExtras.methodSearchPrimitive2(int, int)
+ * @see #methodSearchPrimitive2(long, int)   signature:METHOD:ReferenceTestExtras.methodSearchPrimitive2(long, int)
+ * @see #methodSearchPrimitive2(int, long)   signature:METHOD:ReferenceTestExtras.methodSearchPrimitive2(int, long)
+ * @see #methodSearchPrimitive2(long, long)   signature:METHOD:ReferenceTestExtras.methodSearchPrimitive2(long, long)
  */
 class ReferenceTestExtras {
     int ReferenceTestExtras;            // field
@@ -257,6 +266,16 @@ class ReferenceTestExtras {
     void methodSearch(Object o) {}
     void methodSearch(String s) {}
     void methodSearch(CharSequence cs) {}
+
+    void methodSearchPrimitive1(int i, int j) {}
+    void methodSearchPrimitive1(long i, int j) {}
+    void methodSearchPrimitive1(int i, long j) {}
+    void methodSearchPrimitive1(long i, long j) {}
+
+    void methodSearchPrimitive2(long i, long j) {}
+    void methodSearchPrimitive2(int i, long j) {}
+    void methodSearchPrimitive2(long i, int j) {}
+    void methodSearchPrimitive2(int i, int j) {}
 }
 
 


### PR DESCRIPTION
Currently, when javac encounters a javadoc reference, like `@see PrintStream#println(int)`, will first try to find a method `println` in `PrintStream` using subtyping on the argument types, which may find another overload of the method with an argument that is a subtype of `int` - like `println(double)`. Consequently, the link in the javadoc may be to a wrong method.

In this patch, the proposal is to use the subtype search only as a backup option, using the existing check based on `isSameType` first, and only doing an inexact match using subtyping if the more exact match fails to find a method. This fallback should help possible existing broken references to still work as before, while the preferred use of the more exact match should select the correct method in usual correct cases.

This patch fixes some instances of incorrect references in the JDK's javadoc, a diff of the generated javadocs for the JDK mainline is here:
http://cr.openjdk.java.net/~jlahoda/8278373/JDK-8278373.diff

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278373](https://bugs.openjdk.java.net/browse/JDK-8278373): JavacTrees.searchMethod finds incorrect match


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to 8c0ad7f0f8e2b8e77b3f1cf1d728bcc5e04e7549
 * [Jonathan Gibbons](https://openjdk.java.net/census#jjg) (@jonathan-gibbons - **Reviewer**) ⚠️ Review applies to 8c0ad7f0f8e2b8e77b3f1cf1d728bcc5e04e7549


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/79/head:pull/79` \
`$ git checkout pull/79`

Update a local copy of the PR: \
`$ git checkout pull/79` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/79/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 79`

View PR using the GUI difftool: \
`$ git pr show -t 79`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/79.diff">https://git.openjdk.java.net/jdk18/pull/79.diff</a>

</details>
