### PR TITLE
8279515: C1: No inlining through invokedynamic and invokestatic call sites when resolved class is not linked

### DIFF
--- a/src/hotspot/share/c1/c1_GraphBuilder.cpp
+++ b/src/hotspot/share/c1/c1_GraphBuilder.cpp
@@ -2072,9 +2072,11 @@ void GraphBuilder::invoke(Bytecodes::Code code) {
   }
 
   // check if we could do inlining
-  if (!PatchALot && Inline && target->is_loaded() && callee_holder->is_linked() && !patch_for_appendix) {
+  if (!PatchALot && Inline && target->is_loaded() && !patch_for_appendix &&
+      callee_holder->is_loaded()) { // the effect of symbolic reference resolution
+
     // callee is known => check if we have static binding
-    if ((code == Bytecodes::_invokestatic && callee_holder->is_initialized()) || // invokestatic involves an initialization barrier on resolved klass
+    if ((code == Bytecodes::_invokestatic && klass->is_initialized()) || // invokestatic involves an initialization barrier on declaring class
         code == Bytecodes::_invokespecial ||
         (code == Bytecodes::_invokevirtual && target->is_final_method()) ||
         code == Bytecodes::_invokedynamic) {

--- a/src/hotspot/share/ci/ciStreams.cpp
+++ b/src/hotspot/share/ci/ciStreams.cpp
@@ -476,8 +476,9 @@ ciKlass* ciBytecodeStream::get_declared_method_holder() {
   constantPoolHandle cpool(THREAD, _method->get_Method()->constants());
   bool ignore;
   // report as MethodHandle for invokedynamic, which is syntactically classless
-  if (cur_bc() == Bytecodes::_invokedynamic)
-    return CURRENT_ENV->get_klass_by_name(_holder, ciSymbols::java_lang_invoke_MethodHandle(), false);
+  if (cur_bc() == Bytecodes::_invokedynamic) {
+    return CURRENT_ENV->MethodHandle_klass();
+  }
   return CURRENT_ENV->get_klass_by_index(cpool, get_method_holder_index(), ignore, _holder);
 }
 

--- a/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
+++ b/src/java.base/share/classes/java/lang/invoke/InvokerBytecodeGenerator.java
@@ -683,6 +683,7 @@ class InvokerBytecodeGenerator {
     }
 
     private static MemberName resolveFrom(String name, MethodType type, Class<?> holder) {
+        assert(!UNSAFE.shouldBeInitialized(holder)) : holder + "not initialized";
         MemberName member = new MemberName(holder, name, type, REF_invokeStatic);
         MemberName resolvedMember = MemberName.getFactory().resolveOrNull(REF_invokeStatic, member, holder, LM_TRUSTED);
         traceLambdaForm(name, type, holder, resolvedMember);

--- a/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
+++ b/test/hotspot/jtreg/compiler/inlining/ResolvedClassTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8279515
+ *
+ * @requires vm.flagless
+ * @modules java.base/jdk.internal.misc
+ * @library /test/lib /
+ *
+ * @run driver compiler.jsr292.ResolvedClassTest
+ */
+
+package compiler.jsr292;
+
+import jdk.test.lib.process.OutputAnalyzer;
+import jdk.test.lib.process.ProcessTools;
+
+import java.io.IOException;
+
+public class ResolvedClassTest {
+    /* ======================================================================== */
+    static void testStatic() throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+IgnoreUnrecognizedVMOptions", "-showversion",
+                "-XX:+PrintCompilation", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
+                "-Xbatch", "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly," + TestStatic.class.getName() + "::test",
+                TestStatic.class.getName());
+
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+
+        analyzer.shouldHaveExitValue(0);
+
+        analyzer.shouldNotContain("TestStatic$A::m (1 bytes)   not inlineable");
+        analyzer.shouldNotContain("TestStatic$A::m (1 bytes)   no static binding");
+
+        analyzer.shouldContain("TestStatic$A::m (1 bytes)   inline");
+    }
+
+    static class TestStatic {
+        static class A {
+            static void m() {}
+        }
+        static class B extends A {}
+
+        // @DontInline
+        static void test() {
+            B.m(); // invokestatic B "m" => A::m
+        }
+
+        public static void main(String[] args) {
+            for (int i = 0; i < 20_000; i++) {
+                test();
+            }
+        }
+    }
+
+    /* ======================================================================== */
+    static void testStaticInit() throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+IgnoreUnrecognizedVMOptions", "-showversion",
+                "-XX:+PrintCompilation", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
+                "-Xbatch", "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly," + TestStaticInit.class.getName() + "::test",
+                TestStaticInit.class.getName());
+
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+
+        analyzer.shouldHaveExitValue(0);
+
+        analyzer.shouldContain("TestStaticInit$A::m (1 bytes)   no static binding");
+    }
+
+    static class TestStaticInit {
+        static class A {
+            static {
+                for (int i = 0; i < 20_000; i++) {
+                    TestStaticInit.test();
+                }
+            }
+
+            static void m() {}
+        }
+        static class B extends A {}
+
+        // @DontInline
+        static void test() {
+            B.m(); // A::<clinit> => test() => A::m()
+        }
+
+        public static void main(String[] args) {
+            A.m(); // trigger initialization of A
+        }
+    }
+
+    /* ======================================================================== */
+    static void testIndy() throws IOException {
+        ProcessBuilder pb = ProcessTools.createJavaProcessBuilder(
+                "-XX:+IgnoreUnrecognizedVMOptions", "-showversion",
+                "-XX:+PrintCompilation", "-XX:+UnlockDiagnosticVMOptions", "-XX:+PrintInlining",
+                "-Xbatch", "-XX:CompileCommand=quiet", "-XX:CompileCommand=compileonly," + TestIndy.class.getName() + "::test",
+                TestIndy.class.getName());
+
+        OutputAnalyzer analyzer = new OutputAnalyzer(pb.start());
+
+        analyzer.shouldHaveExitValue(0);
+
+        analyzer.shouldNotContain("java.lang.invoke.Invokers$Holder::linkToTargetMethod (9 bytes)   not inlineable");
+
+        analyzer.shouldContain("java.lang.invoke.Invokers$Holder::linkToTargetMethod (9 bytes)   force inline by annotation");
+        analyzer.shouldContain("java/lang/invoke/MethodHandle::invokeBasic (not loaded)   not inlineable");
+    }
+
+    static class TestIndy {
+        static String str = "";
+
+        // @DontInline
+        static void test() {
+            String s1 = "" + str; // indy (linked)
+
+            for (int i = 0; i < 200_000; i++) {} // trigger OSR compilation
+
+            String s2 = "" + str; // indy (not linked)
+        }
+
+        public static void main(String[] args) {
+            test();
+        }
+    }
+
+    /* ======================================================================== */
+
+    public static void main(String[] args) throws IOException {
+        testStatic();
+        testStaticInit();
+        testIndy();
+    }
+}


### PR DESCRIPTION
[JDK-8267806](https://bugs.openjdk.java.net/browse/JDK-8267806) broke inlining at `invokedynamic` and `invokestatic` call sites in some circumstances. Though the enhancement was intended to relax the inlining checks, it introduced one new check to ensure that resolved klass (`REFC`) is linked. It turned out the check is too strong: resolution of the symbolic class reference at a call site does not trigger class linkage.  

For `invokestatic` consider the following example:
```
class A { static m() { ... } }
class B extends A {}

invokestatic "B"::"m" => A::m
```

Method resolution loads class `B` along the way, but neither initialises nor links it. Invocation does trigger class initialisation, but only for class `A`. 

For `invokedynamic` it's a bit more complicated. Syntactically, there's no symbolic class reference at the call site, but CI assigns an artificial one (`java.lang.invoke.MethodHandle`, see `ciBytecodeStream::get_declared_method_holder()`). The problem is `MethodHandle` class doesn't have to be loaded by the class loader of the accessing class, so `ciEnv::get_klass_by_name()` can produce unloaded CI mirror (`ciKlass`).

For example, indy call site linkage of indified string concatenation (`StringConcatFactory.makeConcatWithConstants()`) doesn't get `MethodHandle` class recorded in the context class loader [1]  while `LambdaMetafactory.metafactory()` introduces a class loader constraint for it [2] which reveals the class to the subsequent class lookup.  ​

I decided to make `ciBytecodeStream::get_declared_method_holder()` predictable and return well-known VM class right away without doing the lookup.

Proposed fix relaxes the constraint on resolved class (`REFC`) and requires it to be loaded.

Also, while working on the fix, I spotted that the constraint for `invokestatic` is also too strong (requires resolved class to be initialized while the specification mandates resolved method holder to be initialized instead):
```
    if ((code == Bytecodes::_invokestatic && callee_holder->is_initialized()) || // invokestatic involves an initialization barrier on resolved klass
```

I fixed it as well (`s/callee_holder/klass/`).

Testing: hs-tier1 - hs-tier4

[1]
```
[0.160s][debug][class,resolve           ] Test1 java.lang.invoke.StringConcatFactory Test.java:3
[0.160s][info ][class,loader,constraints] adding new constraint for name: java/lang/invoke/MethodHandles$Lookup, loader[0]: 'app', loader[1]: 'bootstrap'
[0.160s][info ][class,loader,constraints] adding new constraint for name: java/lang/invoke/MethodType, loader[0]: 'app', loader[1]: 'bootstrap'
[0.160s][info ][class,loader,constraints] adding new constraint for name: java/lang/invoke/CallSite, loader[0]: 'app', loader[1]: 'bootstrap'
```

[2] 
```
[0.130s][debug][class,resolve          ] Test java.lang.invoke.LambdaMetafactory Test.java:21
[0.130s][info ][class,loader,constraints] adding new constraint for name: java/lang/invoke/MethodHandles$Lookup, loader[0]: 'app', loader[1]: 'bootstrap'
[0.130s][info ][class,loader,constraints] adding new constraint for name: java/lang/invoke/MethodType, loader[0]: 'app', loader[1]: 'bootstrap'
[0.130s][info ][class,loader,constraints] adding new constraint for name: java/lang/invoke/MethodHandle, loader[0]: 'app', loader[1]: 'bootstrap'
[0.130s][info ][class,loader,constraints] adding new constraint for name: java/lang/invoke/CallSite, loader[0]: 'app', loader[1]: 'bootstrap'
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279515](https://bugs.openjdk.java.net/browse/JDK-8279515): C1: No inlining through invokedynamic and invokestatic call sites when resolved class is not linked


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.java.net/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/80/head:pull/80` \
`$ git checkout pull/80`

Update a local copy of the PR: \
`$ git checkout pull/80` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/80/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 80`

View PR using the GUI difftool: \
`$ git pr show -t 80`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/80.diff">https://git.openjdk.java.net/jdk18/pull/80.diff</a>

</details>
