### PR TITLE
8279527: Dereferencing segments backed by different scopes leads to pollution

### DIFF
--- a/src/java.base/share/classes/java/nio/Buffer.java
+++ b/src/java.base/share/classes/java/nio/Buffer.java
@@ -767,7 +767,11 @@ public abstract class Buffer {
     final void checkScope() {
         ScopedMemoryAccess.Scope scope = scope();
         if (scope != null) {
-            scope.checkValidState();
+            try {
+                scope.checkValidState();
+            } catch (ScopedMemoryAccess.Scope.ScopedAccessError e) {
+                throw new IllegalStateException("This segment is already closed");
+            }
         }
     }
 

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -364,11 +364,7 @@ public abstract non-sealed class AbstractMemorySegmentImpl extends MemorySegment
     }
 
     void checkValidState() {
-        try {
-            scope.checkValidState();
-        } catch (ScopedMemoryAccess.Scope.ScopedAccessError ex) {
-            throw new IllegalStateException("This segment is already closed");
-        }
+        scope.checkValidStateSlow();
     }
 
     @Override

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeSymbolImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/NativeSymbolImpl.java
@@ -28,11 +28,12 @@ package jdk.internal.foreign;
 import jdk.incubator.foreign.MemoryAddress;
 import jdk.incubator.foreign.NativeSymbol;
 import jdk.incubator.foreign.ResourceScope;
+import jdk.internal.misc.ScopedMemoryAccess;
 
 public record NativeSymbolImpl(String name, MemoryAddress address, ResourceScope scope) implements NativeSymbol, Scoped {
     @Override
     public MemoryAddress address() {
-        ((ResourceScopeImpl)scope).checkValidState();
+        ((ResourceScopeImpl)scope).checkValidStateSlow();
         return address;
     }
 }

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
@@ -201,7 +201,7 @@ public abstract non-sealed class ResourceScopeImpl implements ResourceScope, Seg
      * a confined scope and this method is called outside of the owner thread.
      */
     public final void checkValidStateSlow() {
-        if (ownerThread() != null && Thread.currentThread() != ownerThread()) {
+        if (owner != null && Thread.currentThread() != owner) {
             throw new IllegalStateException("Attempted access outside owning thread");
         } else if (!isAlive()) {
             throw new IllegalStateException("Already closed");

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/ResourceScopeImpl.java
@@ -32,6 +32,8 @@ import jdk.incubator.foreign.SegmentAllocator;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.vm.annotation.ForceInline;
 
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
 import java.lang.ref.Cleaner;
 import java.lang.ref.Reference;
 import java.util.Objects;
@@ -53,6 +55,23 @@ public abstract non-sealed class ResourceScopeImpl implements ResourceScope, Seg
 
     final ResourceList resourceList;
     final Cleaner.Cleanable cleanable;
+    final Thread owner;
+
+    static final int ALIVE = 0;
+    static final int CLOSING = -1;
+    static final int CLOSED = -2;
+
+    int state = ALIVE;
+
+    static final VarHandle STATE;
+
+    static {
+        try {
+            STATE = MethodHandles.lookup().findVarHandle(ResourceScopeImpl.class, "state", int.class);
+        } catch (Throwable ex) {
+            throw new ExceptionInInitializerError(ex);
+        }
+    }
 
     static final int MAX_FORKS = Integer.MAX_VALUE;
 
@@ -89,7 +108,8 @@ public abstract non-sealed class ResourceScopeImpl implements ResourceScope, Seg
         }
     }
 
-    protected ResourceScopeImpl(ResourceList resourceList, Cleaner cleaner) {
+    protected ResourceScopeImpl(Thread owner, ResourceList resourceList, Cleaner cleaner) {
+        this.owner = owner;
         this.resourceList = resourceList;
         cleanable = (cleaner != null) ?
             cleaner.register(this, resourceList) : null;
@@ -147,7 +167,9 @@ public abstract non-sealed class ResourceScopeImpl implements ResourceScope, Seg
      * Returns "owner" thread of this scope.
      * @return owner thread (or null for a shared scope)
      */
-    public abstract Thread ownerThread();
+    public final Thread ownerThread() {
+        return owner;
+    }
 
     /**
      * Returns true, if this scope is still alive. This method may be called in any thread.
@@ -155,14 +177,23 @@ public abstract non-sealed class ResourceScopeImpl implements ResourceScope, Seg
      */
     public abstract boolean isAlive();
 
-
     /**
      * This is a faster version of {@link #checkValidStateSlow()}, which is called upon memory access, and which
-     * relies on invariants associated with the memory scope implementations (typically, volatile access
-     * to the closed state bit is replaced with plain access, and ownership check is removed where not needed.
-     * Should be used with care.
+     * relies on invariants associated with the memory scope implementations (volatile access
+     * to the closed state bit is replaced with plain access). This method should be monomorphic,
+     * to avoid virtual calls in the memory access hot path. This method is not intended as general purpose method
+     * and should only be used in the memory access handle hot path; for liveness checks triggered by other API methods,
+     * please use {@link #checkValidStateSlow()}.
      */
-    public abstract void checkValidState();
+    @ForceInline
+    public final void checkValidState() {
+        if (owner != null && owner != Thread.currentThread()) {
+            throw new IllegalStateException("Attempted access outside owning thread");
+        }
+        if (state < ALIVE) {
+            throw ScopedAccessError.INSTANCE;
+        }
+    }
 
     /**
      * Checks that this scope is still alive (see {@link #isAlive()}).

--- a/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
+++ b/src/jdk.incubator.foreign/share/classes/jdk/internal/foreign/SharedScope.java
@@ -45,36 +45,8 @@ class SharedScope extends ResourceScopeImpl {
 
     private static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 
-    private static final int ALIVE = 0;
-    private static final int CLOSING = -1;
-    private static final int CLOSED = -2;
-
-    private int state = ALIVE;
-
-    private static final VarHandle STATE;
-
-    static {
-        try {
-            STATE = MethodHandles.lookup().findVarHandle(jdk.internal.foreign.SharedScope.class, "state", int.class);
-        } catch (Throwable ex) {
-            throw new ExceptionInInitializerError(ex);
-        }
-    }
-
     SharedScope(Cleaner cleaner) {
-        super(new SharedResourceList(), cleaner);
-    }
-
-    @Override
-    public Thread ownerThread() {
-        return null;
-    }
-
-    @Override
-    public void checkValidState() {
-        if (state < ALIVE) {
-            throw ScopedAccessError.INSTANCE;
-        }
+        super(null, new SharedResourceList(), cleaner);
     }
 
     @Override

--- a/test/jdk/java/foreign/TestByteBuffer.java
+++ b/test/jdk/java/foreign/TestByteBuffer.java
@@ -369,7 +369,7 @@ public class TestByteBuffer {
             Throwable cause = ex.getCause();
             if (cause instanceof IllegalStateException) {
                 //all get/set buffer operation should fail because of the scope check
-                assertTrue(ex.getCause().getMessage().contains("Already closed"));
+                assertTrue(ex.getCause().getMessage().contains("already closed"));
             } else {
                 //all other exceptions were unexpected - fail
                 fail("Unexpected exception", cause);
@@ -406,7 +406,7 @@ public class TestByteBuffer {
                 handle.invoke(e.getValue());
                 fail();
             } catch (IllegalStateException ex) {
-                assertTrue(ex.getMessage().contains("Already closed"));
+                assertTrue(ex.getMessage().contains("already closed"));
             } catch (UnsupportedOperationException ex) {
                 //skip
             } catch (Throwable ex) {

--- a/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverPollutedSegments.java
+++ b/test/micro/org/openjdk/bench/jdk/incubator/foreign/LoopOverPollutedSegments.java
@@ -58,7 +58,7 @@ public class LoopOverPollutedSegments {
 
     static final Unsafe unsafe = Utils.unsafe;
 
-    MemorySegment nativeSegment, heapSegmentBytes, heapSegmentFloats;
+    MemorySegment nativeSegment, nativeSharedSegment, heapSegmentBytes, heapSegmentFloats;
     byte[] arr;
     long addr;
 
@@ -73,6 +73,7 @@ public class LoopOverPollutedSegments {
         }
         arr = new byte[ALLOC_SIZE];
         nativeSegment = MemorySegment.allocateNative(ALLOC_SIZE, 4, ResourceScope.newConfinedScope());
+        nativeSharedSegment = MemorySegment.allocateNative(ALLOC_SIZE, 4, ResourceScope.newSharedScope());
         heapSegmentBytes = MemorySegment.ofArray(new byte[ALLOC_SIZE]);
         heapSegmentFloats = MemorySegment.ofArray(new float[ELEM_SIZE]);
 
@@ -81,6 +82,8 @@ public class LoopOverPollutedSegments {
                 unsafe.putInt(arr, Unsafe.ARRAY_BYTE_BASE_OFFSET + (i * 4), i);
                 nativeSegment.setAtIndex(JAVA_INT, i, i);
                 nativeSegment.setAtIndex(JAVA_FLOAT, i, i);
+                nativeSharedSegment.setAtIndex(JAVA_INT, i, i);
+                nativeSharedSegment.setAtIndex(JAVA_FLOAT, i, i);
                 intHandle.set(nativeSegment, (long)i, i);
                 heapSegmentBytes.setAtIndex(JAVA_INT, i, i);
                 heapSegmentBytes.setAtIndex(JAVA_FLOAT, i, i);


### PR DESCRIPTION
This patch fixes a performance issue when dereferencing memory segments backed by different kinds of scopes. When looking at inline traces, I found that one of our benchmark, namely `LoopOverPollutedSegment` was already hitting the ceiling of the bimorphic inline cache, specifically when checking liveness of the segment scope in the memory access hotpath (`ResourceScopeImpl::checkValidState`). The benchmark only used segments backed by confined and global scope. I then added (in the initialization "polluting" loop) segments backed by a shared scope, and then the benchmark numbers started to look as follows:

```
Benchmark                                              Mode  Cnt  Score   Error  Units
LoopOverPollutedSegments.heap_segment_floats_VH        avgt   30  7.004 ? 0.089  ms/op
LoopOverPollutedSegments.heap_segment_floats_instance  avgt   30  7.159 ? 0.016  ms/op
LoopOverPollutedSegments.heap_segment_ints_VH          avgt   30  7.017 ? 0.110  ms/op
LoopOverPollutedSegments.heap_segment_ints_instance    avgt   30  7.175 ? 0.048  ms/op
LoopOverPollutedSegments.heap_unsafe                   avgt   30  0.243 ? 0.004  ms/op
LoopOverPollutedSegments.native_segment_VH             avgt   30  7.366 ? 0.036  ms/op
LoopOverPollutedSegments.native_segment_instance       avgt   30  7.305 ? 0.098  ms/op
LoopOverPollutedSegments.native_unsafe                 avgt   30  0.238 ? 0.002  ms/op
```

That is, since now we have *three* different kinds of scopes (confined, shared and global), the call to the liveness check can no longer be inlined. One solution could be, as we do for the *base* accessor, to add a scope accessor to all memory segment implementation classes. But doing so only works ok for heap segments (for which the scope accessor just returns the global scope constants). For native segments, we're still megamorphic (as a native segment can be backed by all kinds of scopes).

In the end, it turned out to be much simpler to just make the liveness check monomorphic, since there's so much sharing between the code paths already. With that change, numbers of the tweaked benchmark go back to normal:

```
Benchmark                                              Mode  Cnt  Score   Error  Units
LoopOverPollutedSegments.heap_segment_floats_VH        avgt   30  0.241 ? 0.003  ms/op
LoopOverPollutedSegments.heap_segment_floats_instance  avgt   30  0.244 ? 0.003  ms/op
LoopOverPollutedSegments.heap_segment_ints_VH          avgt   30  0.242 ? 0.003  ms/op
LoopOverPollutedSegments.heap_segment_ints_instance    avgt   30  0.248 ? 0.001  ms/op
LoopOverPollutedSegments.heap_unsafe                   avgt   30  0.247 ? 0.013  ms/op
LoopOverPollutedSegments.native_segment_VH             avgt   30  0.245 ? 0.004  ms/op
LoopOverPollutedSegments.native_segment_instance       avgt   30  0.245 ? 0.001  ms/op
LoopOverPollutedSegments.native_unsafe                 avgt   30  0.247 ? 0.005  ms/op
```

Note that this patch tidies up a bit the usage of `checkValidState` vs. `checkValidStateSlow`. The former should only really be used in the hot path, while the latter is a more general routine which should be used in non-performance critical code. Making `checkValidState` monomorphic caused the `ScopeAccessError` to be generated in more places, so I needed to either update the usage to use the safer `checkValidStateSlow` (where possible) or, (in `Buffer` and `ConfinedScope`) just add extra wrapping.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279527](https://bugs.openjdk.java.net/browse/JDK-8279527): Dereferencing segments backed by different scopes leads to pollution


### Reviewers
 * [Paul Sandoz](https://openjdk.java.net/census#psandoz) (@PaulSandoz - **Reviewer**) ⚠️ Review applies to 04a1e9f24485390d2db100ea1ce09049a73783f2
 * [Jorn Vernee](https://openjdk.java.net/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/82.diff">https://git.openjdk.java.net/jdk18/pull/82.diff</a>

</details>
