### PR TITLE
8279398: jdk/jfr/api/recording/time/TestTimeMultiple.java failed with "RuntimeException: getStopTime() > afterStop"

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -296,7 +296,6 @@ public final class MetadataRepository {
             }
             unregistered = false;
         }
-        
         return Utils.epochNanosToInstant(chunkStart);
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -280,9 +280,12 @@ public final class MetadataRepository {
         if (staleMetadata) {
             storeDescriptorInJVM();
         }
-        awaitUniqueTimestamp();
         jvm.setOutput(filename);
-        long nanos = jvm.getChunkStartNanos();
+        // Each chunk needs a unique start timestamp and
+        // if the clock resolution is low, two chunks may
+        // get the same timestamp. Utils.getChunkStartNanos()
+        // ensures the timestamp is unique for the next chunk
+        long chunkStart = Utils.getChunkStartNanos();
         if (filename != null) {
             RepositoryFiles.notifyNewFile();
         }
@@ -293,29 +296,8 @@ public final class MetadataRepository {
             }
             unregistered = false;
         }
-        return Utils.epochNanosToInstant(nanos);
-    }
-
-    // Each chunk needs a unique start timestamp and
-    // if the clock resolution is low, two chunks may
-    // get the same timestamp.
-    private void awaitUniqueTimestamp() {
-        if (outputChange == null) {
-            outputChange = Instant.now();
-            return;
-        }
-        while (true) {
-            Instant time = Instant.now();
-            if (!time.equals(outputChange)) {
-                outputChange = time;
-                return;
-            }
-            try {
-                Thread.sleep(0, 100);
-            } catch (InterruptedException iex) {
-                // ignore
-            }
-        }
+        
+        return Utils.epochNanosToInstant(chunkStart);
     }
 
     private void unregisterUnloaded() {

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/PlatformRecorder.java
@@ -248,7 +248,7 @@ public final class PlatformRecorder {
             }
             currentChunk = newChunk;
             jvm.beginRecording();
-            startNanos = jvm.getChunkStartNanos();
+            startNanos = Utils.getChunkStartNanos();
             startTime = Utils.epochNanosToInstant(startNanos);
             if (currentChunk != null) {
                 currentChunk.setStartTime(startTime);
@@ -269,7 +269,7 @@ public final class PlatformRecorder {
                 startTime = MetadataRepository.getInstance().setOutput(p);
                 newChunk.setStartTime(startTime);
             }
-            startNanos = jvm.getChunkStartNanos();
+            startNanos = Utils.getChunkStartNanos();
             startTime = Utils.epochNanosToInstant(startNanos);
             recording.setStartTime(startTime);
             recording.setState(RecordingState.RUNNING);
@@ -316,7 +316,7 @@ public final class PlatformRecorder {
             }
         }
         OldObjectSample.emit(recording);
-        recording.setFinalStartnanos(jvm.getChunkStartNanos());
+        recording.setFinalStartnanos(Utils.getChunkStartNanos());
 
         if (endPhysical) {
             RequestEngine.doChunkEnd();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -870,8 +870,8 @@ public final class Utils {
 
     public static long getChunkStartNanos() {
         long nanos = JVM.getJVM().getChunkStartNanos();
-        // JVM::getChunkStartNanos() may returns an artificially bumped
-        // timestamp. Spin here to give Instant.now() a chance to catch up.
+        // JVM::getChunkStartNanos() may return a bumped timestamp, +1 ns or +2 ns.
+        // Spin here to give Instant.now() a chance to catch up.
         awaitUniqueTimestamp();
         return nanos;
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -97,6 +97,7 @@ public final class Utils {
      * The possible data race is benign and is worth of not introducing any contention here.
      */
     private static Metrics[] metrics;
+    private static Instant lastTimestamp;
 
     public static void checkAccessFlightRecorder() throws SecurityException {
         @SuppressWarnings("removal")
@@ -864,6 +865,32 @@ public final class Utils {
     public static void ensureJavaIdentifier(String name) {
         if (!Checks.isJavaIdentifier(name)) {
             throw new IllegalArgumentException("'" + name + "' is not a valid Java identifier");
+        }
+    }
+
+    public static long getChunkStartNanos() {
+        long nanos = JVM.getJVM().getChunkStartNanos();
+        // JVM::getChunkStartNanos() may returns an artificially bumped
+        // timestamp. Spin here to give Instant.now() a chance to catch up.
+        awaitUniqueTimestamp();
+        return nanos;
+    }
+
+    private static void awaitUniqueTimestamp() {
+        if (lastTimestamp == null) {
+            lastTimestamp = Instant.now(); // lazy initialization
+        }
+        while (true) {
+            Instant time = Instant.now();
+            if (!time.equals(lastTimestamp)) {
+                lastTimestamp = time;
+                return;
+            }
+            try {
+                Thread.sleep(0, 100);
+            } catch (InterruptedException iex) {
+                // ignore
+            }
         }
     }
 }


### PR DESCRIPTION
Hi,

Could I have review of a fix of a regression introduced with "JDK-8268297: jdk/jfr/api/consumer/streaming/TestLatestEvent.java times out" https://bugs.openjdk.java.net/browse/JDK-8268297

Bumping the timestamp in native, if the timestamp has not changed, ensures that chunks gets a strictly increasing start time, which is needed for event streaming to order chunks chronologically.

Problem is that tests, and probably users as well, expect that the start/stop time of a recording never exceeds what a later invocation to Instant.now() returns, for example:
```
Recording a = new Recording();
a.start(); // first chunk begins 
a.stop(); // first chunk ends
Recording b = new Recording();
b.start(); // second chunk begins, where time stamp is taken and possibly bumped with a nanosecond.
Instant now = Instant.now();
if (now.isBefore(b.getStartTime())) {
  System.out.println("WAT");
}
```
This can happen on Windows where the clock has low resolution, so Recording::start() may finish execution without a clock change. The fix is to let methods that creates a new chunk spin until the clock has catched up.

To verify the fix, I modified the test jdk/jdk/jfr/api/recoding/time/TestTimeMultiple.java so it executes code similar to above 100 times per test and then ran the test 200 times without failures. Without the fix, failures were frequent.

Technically, it's not necessary for all places to use Utils::getChunkStartNanos() instead of JVM::getChunkStartNanos(), but it seemed more prudent to never use the low level function, which can in some circumstances lead to incorrect behavior.

Thanks
Erik

<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279398](https://bugs.openjdk.java.net/browse/JDK-8279398): jdk/jfr/api/recording/time/TestTimeMultiple.java failed with "RuntimeException: getStopTime() > afterStop"


### Reviewers
 * [Markus Grönlund](https://openjdk.java.net/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/84/head:pull/84` \
`$ git checkout pull/84`

Update a local copy of the PR: \
`$ git checkout pull/84` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/84/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 84`

View PR using the GUI difftool: \
`$ git pr show -t 84`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/84.diff">https://git.openjdk.java.net/jdk18/pull/84.diff</a>

</details>
