### PR TITLE
8278930: javac tries to compile a file twice via PackageElement.getEnclosedElements

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/ClassFinder.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/ClassFinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1999, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/code/ClassFinder.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/code/ClassFinder.java
@@ -292,10 +292,16 @@ public class ClassFinder {
                 ClassSymbol c = (ClassSymbol) sym;
                 dependencies.push(c, CompletionCause.CLASS_READER);
                 annotate.blockAnnotations();
-                c.members_field = new Scope.ErrorScope(c); // make sure it's always defined
+                Scope.ErrorScope members = new Scope.ErrorScope(c);
+                c.members_field = members; // make sure it's always defined
                 completeOwners(c.owner);
                 completeEnclosing(c);
-                fillIn(c);
+                //if an enclosing class is completed from the source,
+                //this class might have been completed already as well,
+                //avoid attempts to re-complete it:
+                if (c.members_field == members) {
+                    fillIn(c);
+                }
             } finally {
                 annotate.unblockAnnotationsNoFlush();
                 dependencies.pop();

--- a/test/langtools/tools/javac/processing/model/element/TestListPackageFromAPI.java
+++ b/test/langtools/tools/javac/processing/model/element/TestListPackageFromAPI.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8278930
+ * @summary Check that when a package has Elements listed from both from classes and sources,
+ *          and then a nested class is completed, it is not first completed from source via
+ *          its enclosing class, and then again for itself.
+ * @library /tools/javac/lib
+ * @modules java.compiler
+ *          jdk.compiler
+ * @run main TestListPackageFromAPI
+ */
+
+import com.sun.source.util.JavacTask;
+import java.io.IOException;
+import java.io.Writer;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import javax.lang.model.element.PackageElement;
+import javax.tools.DiagnosticListener;
+import javax.tools.ForwardingJavaFileManager;
+import javax.tools.JavaFileManager;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.SimpleJavaFileObject;
+import javax.tools.StandardLocation;
+import javax.tools.ToolProvider;
+
+public class TestListPackageFromAPI {
+
+    public static void main(String... args) throws IOException, URISyntaxException, InterruptedException {
+        Path base = Paths.get(".");
+        Path src = base.resolve("src");
+        Path classes = base.resolve("classes");
+
+        Files.createDirectories(src);
+        Files.createDirectories(classes);
+
+        Files.newOutputStream(classes.resolve("Test$Nested1.class")).close();
+        Files.newOutputStream(classes.resolve("Test.class")).close();
+
+        Thread.sleep(2000);
+
+        Path testSource = src.resolve("Test.java");
+
+        try (Writer w = Files.newBufferedWriter(testSource)) {
+            w.write("""
+                    public class Test {
+                        public static class Nested {}
+                    }
+                    """);
+        }
+        try (JavaFileManager fm = ToolProvider.getSystemJavaCompiler().getStandardFileManager(null, null, null)) {
+            List<JavaFileObject> testClasses = List.of(
+                new TestFileObject("Test"),
+                new TestFileObject("Test$Nested")
+            );
+            List<JavaFileObject> testSources = List.of(
+                    new TestFileObject("Test",
+                                       """
+                                       public class Test {
+                                           public static class Nested1 {}
+                                       }
+                                       """)
+            );
+            JavaFileManager testFM = new ForwardingJavaFileManagerImpl(fm, testClasses, testSources);
+            DiagnosticListener<JavaFileObject> noErrors = d -> { throw new AssertionError("Should not happen: " + d); };
+            JavacTask task = (JavacTask) ToolProvider.getSystemJavaCompiler().getTask(null, testFM, noErrors, List.of("--class-path", classes.toString(), "-sourcepath", src.toString()), null, List.of(new TestFileObject("Input", "")));
+            PackageElement pack = task.getElements().getPackageElement("");
+            pack.getEnclosedElements().forEach(e -> System.err.println(e));
+        }
+    }
+
+    private static class TestFileObject extends SimpleJavaFileObject {
+
+        private final String className;
+        private final String code;
+
+        public TestFileObject(String className) throws URISyntaxException {
+            super(new URI("mem://" + className + ".class"), Kind.CLASS);
+            this.className = className;
+            this.code = null;
+        }
+
+        public TestFileObject(String className, String code) throws URISyntaxException {
+            super(new URI("mem://" + className + ".class"), Kind.SOURCE);
+            this.className = className;
+            this.code = code;
+        }
+
+        @Override
+        public CharSequence getCharContent(boolean ignoreEncodingErrors) throws IOException {
+            if (code == null) {
+                throw new UnsupportedOperationException();
+            }
+            return code;
+        }
+
+        @Override
+        public long getLastModified() {
+            return getKind() == Kind.CLASS ? 0 : 1000;
+        }
+
+    }
+
+    private static class ForwardingJavaFileManagerImpl extends ForwardingJavaFileManager<JavaFileManager> {
+
+        private final List<JavaFileObject> testClasses;
+        private final List<JavaFileObject> testSources;
+
+        public ForwardingJavaFileManagerImpl(JavaFileManager fileManager, List<JavaFileObject> testClasses, List<JavaFileObject> testSources) {
+            super(fileManager);
+            this.testClasses = testClasses;
+            this.testSources = testSources;
+        }
+
+        @Override
+        public Iterable<JavaFileObject> list(JavaFileManager.Location location, String packageName, Set<JavaFileObject.Kind> kinds, boolean recurse) throws IOException {
+            if (location == StandardLocation.CLASS_PATH && packageName.isEmpty()) {
+                List<JavaFileObject> result = new ArrayList<>();
+                if (kinds.contains(Kind.CLASS)) {
+                    result.addAll(testClasses);
+                }
+                if (kinds.contains(Kind.SOURCE)) {
+                    result.addAll(testSources);
+                }
+                return result;
+            }
+            return super.list(location, packageName, kinds, recurse);
+        }
+
+        @Override
+        public String inferBinaryName(JavaFileManager.Location location, JavaFileObject file) {
+            if (file instanceof TestFileObject testFO) {
+                return testFO.className;
+            }
+            return super.inferBinaryName(location, file);
+        }
+    }
+}


### PR DESCRIPTION
When using the Elements API, it may happen that an inner class is being completed before its enclosing class. The code is generally prepared for that, and will complete the enclosing class before filling in the content of the inner class.

An issue happens if the enclosing class is completed from source. Then, since [JDK-8224922](https://bugs.openjdk.java.net/browse/JDK-8224922), the innerclass' `ClassSymbol.classfile` will be set to the source file as well, and then javac will try to fill the innerclass from the source code again, leading to duplicate class error. (Before JDK-8224922, the innerclass was, as far as I can tell, completed from the classfile, which didn't lead to this specific problem, but is unlikely to be completely correct either.)

The proposal in this fix is to detect the situation where the nested class was already filled after the enclosing class has been completed, and skip further processing.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278930](https://bugs.openjdk.java.net/browse/JDK-8278930): javac tries to compile a file twice via PackageElement.getEnclosedElements


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**) ⚠️ Review applies to c3473de4860e18b649daa5cbade86e1376163711


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/85.diff">https://git.openjdk.java.net/jdk18/pull/85.diff</a>

</details>
