### PR TITLE
8278344: sun/security/pkcs12/KeytoolOpensslInteropTest.java test fails because of different openssl output

### DIFF
--- a/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
+++ b/test/jdk/sun/security/pkcs12/KeytoolOpensslInteropTest.java
@@ -462,7 +462,7 @@ public class KeytoolOpensslInteropTest {
                 "pkcs12", "-in", "ksnormal", "-passin", "pass:changeit",
                 "-info", "-nokeys", "-nocerts");
         output1.shouldHaveExitValue(0)
-            .shouldContain("MAC: sha256, Iteration 10000")
+            .shouldContain("MAC:").shouldContain("sha256").shouldContain("Iteration 10000")
             .shouldContain("Shrouded Keybag: PBES2, PBKDF2, AES-256-CBC,"
                     + " Iteration 10000, PRF hmacWithSHA256")
             .shouldContain("PKCS7 Encrypted data: PBES2, PBKDF2, AES-256-CBC,"
@@ -505,7 +505,7 @@ public class KeytoolOpensslInteropTest {
                 "ksnewic", "-passin", "pass:changeit", "-info", "-nokeys",
                 "-nocerts");
         output1.shouldHaveExitValue(0)
-            .shouldContain("MAC: sha256, Iteration 5555")
+            .shouldContain("MAC:").shouldContain("sha256").shouldContain("Iteration 5555")
             .shouldContain("Shrouded Keybag: PBES2, PBKDF2, AES-256-CBC,"
                     + " Iteration 7777, PRF hmacWithSHA256")
             .shouldContain("Shrouded Keybag: pbeWithSHA1And128BitRC4,"


### PR DESCRIPTION
<!--
Replace this text with a description of your pull request (also remove the surrounding HTML comment markers).
If in doubt, feel free to delete everything in this edit box first, the bot will restore the progress section as needed.
-->

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278344](https://bugs.openjdk.java.net/browse/JDK-8278344): sun/security/pkcs12/KeytoolOpensslInteropTest.java test fails because of different openssl output


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/90/head:pull/90` \
`$ git checkout pull/90`

Update a local copy of the PR: \
`$ git checkout pull/90` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/90/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 90`

View PR using the GUI difftool: \
`$ git pr show -t 90`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/90.diff">https://git.openjdk.java.net/jdk18/pull/90.diff</a>

</details>
