### PR TITLE
8279597: [TESTBUG] ReturnBlobToWrongHeapTest.java fails with -XX:TieredStopAtLevel=1 on machines with many cores

### DIFF
--- a/test/hotspot/jtreg/compiler/codecache/stress/ReturnBlobToWrongHeapTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/ReturnBlobToWrongHeapTest.java
@@ -35,8 +35,9 @@
  *                   -XX:+WhiteBoxAPI
  *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
  *                   -XX:+SegmentedCodeCache
- *                   -XX:ReservedCodeCacheSize=64M
+ *                   -XX:ReservedCodeCacheSize=16M
  *                   -XX:CodeCacheMinBlockLength=1
+ *                   -XX:CICompilerCount=2
  *                   compiler.codecache.stress.ReturnBlobToWrongHeapTest
  */
 
@@ -47,7 +48,7 @@ import sun.hotspot.code.BlobType;
 import java.util.ArrayList;
 
 public class ReturnBlobToWrongHeapTest {
-    private static final long largeBlobSize = Helper.WHITE_BOX.getUintxVMFlag("ReservedCodeCacheSize") >> 8;
+    private static final long largeBlobSize = Helper.WHITE_BOX.getUintxVMFlag("ReservedCodeCacheSize") >> 6;
     private static final long codeCacheMinBlockLength = Helper.WHITE_BOX.getUintxVMFlag("CodeCacheMinBlockLength");
     private static final BlobType[] BLOB_TYPES = BlobType.getAvailable().toArray(new BlobType[0]);
 

--- a/test/hotspot/jtreg/compiler/codecache/stress/ReturnBlobToWrongHeapTest.java
+++ b/test/hotspot/jtreg/compiler/codecache/stress/ReturnBlobToWrongHeapTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -35,7 +35,7 @@
  *                   -XX:+WhiteBoxAPI
  *                   -XX:CompileCommand=dontinline,compiler.codecache.stress.Helper$TestCase::method
  *                   -XX:+SegmentedCodeCache
- *                   -XX:ReservedCodeCacheSize=16M
+ *                   -XX:ReservedCodeCacheSize=64M
  *                   -XX:CodeCacheMinBlockLength=1
  *                   compiler.codecache.stress.ReturnBlobToWrongHeapTest
  */
@@ -47,7 +47,7 @@ import sun.hotspot.code.BlobType;
 import java.util.ArrayList;
 
 public class ReturnBlobToWrongHeapTest {
-    private static final long largeBlobSize = Helper.WHITE_BOX.getUintxVMFlag("ReservedCodeCacheSize") >> 6;
+    private static final long largeBlobSize = Helper.WHITE_BOX.getUintxVMFlag("ReservedCodeCacheSize") >> 8;
     private static final long codeCacheMinBlockLength = Helper.WHITE_BOX.getUintxVMFlag("CodeCacheMinBlockLength");
     private static final BlobType[] BLOB_TYPES = BlobType.getAvailable().toArray(new BlobType[0]);
 


### PR DESCRIPTION
This test failure occurred on machines with a lot of cores. Here is a
snippet from the log file:

```
----------System.out:(14/1085)----------
CompileCommand: dontinline compiler/codecache/stress/Helper$TestCase.method bool dontinline = true
[0.046s][warning][codecache] CodeHeap 'non-profiled nmethods' is full. Compiler has been disabled.
[0.046s][warning][codecache] Try increasing the code heap size using -XX:NonProfiledCodeHeapSize=
CodeHeap 'non-profiled nmethods': size=8Kb used=7Kb max_used=7Kb free=0Kb
 bounds [0x0000ffff97b55000, 0x0000ffff97b57000, 0x0000ffff97b57000]
CodeHeap 'non-nmethods': size=16376Kb used=941Kb max_used=941Kb free=15434Kb
 bounds [0x0000ffff96b57000, 0x0000ffff96dc7000, 0x0000ffff97b55000]
 total_blobs=269 nmethods=8 adapters=194
 compilation: disabled (not enough contiguous free space left)
 stopped_count=1, restarted_count=0
 full_count=1
Error occurred during initialization of boot layer
java.lang.InternalError: java.lang.NoSuchMethodException: no such method: java.lang.invoke.MethodHandle.linkToStatic(MemberName)Object/invokeStatic
Caused by: java.lang.NoSuchMethodException: no such method: java.lang.invoke.MethodHandle.linkToStatic(MemberName)Object/invokeStatic
```

On machines with many cores, the number of C1 temporary code buffers is
big. See [1]. In my local test on a machine with 224 cores, `c1_count`
equals to 21, and the total size for non-nmethod heap increases to about
16.5M.

In this test case, `ReservedCodeCacheSize` is set as 16M, which is not
enough for the non-nmethod heap. See [2]. As a result, non-profiled heap
is set to (twice) the minimal size. As shown in the log file, the size
is only 8Kb, which is very small and leads to failure at initialization
phase.

In this patch, we increase `ReservedCodeCacheSize` from 16M to 64M,
which is big enough for machines with 1024 cores. Note that we continue
to use the initial value for variable `largeBlobSize`.

[1] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/code/codeCache.cpp#L200
[2] https://github.com/openjdk/jdk/blob/master/src/hotspot/share/code/codeCache.cpp#L216

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279597](https://bugs.openjdk.java.net/browse/JDK-8279597): [TESTBUG] ReturnBlobToWrongHeapTest.java fails with -XX:TieredStopAtLevel=1 on machines with many cores


### Reviewers
 * [Vladimir Kozlov](https://openjdk.java.net/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/93/head:pull/93` \
`$ git checkout pull/93`

Update a local copy of the PR: \
`$ git checkout pull/93` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/93/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 93`

View PR using the GUI difftool: \
`$ git pr show -t 93`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/93.diff">https://git.openjdk.java.net/jdk18/pull/93.diff</a>

</details>
