### PR TITLE
8279998: PPC64 debug builds fail with "untested: RangeCheckStub: predicate_failed_trap_id"

### DIFF
--- a/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
+++ b/src/hotspot/cpu/ppc/c1_CodeStubs_ppc.cpp
@@ -81,8 +81,6 @@ void RangeCheckStub::emit_code(LIR_Assembler* ce) {
 
   if (_info->deoptimize_on_exception()) {
     address a = Runtime1::entry_for(Runtime1::predicate_failed_trap_id);
-    // May be used by optimizations like LoopInvariantCodeMotion or RangeCheckEliminator.
-    DEBUG_ONLY( __ untested("RangeCheckStub: predicate_failed_trap_id"); )
     //__ load_const_optimized(R0, a);
     __ add_const_optimized(R0, R29_TOC, MacroAssembler::offset_to_global_toc(a));
     __ mtctr(R0);


### PR DESCRIPTION
Redoing https://github.com/openjdk/jdk/pull/7077 for JDK 18.

Current mainline fails bootcycle-images build with hitting the `__ untested` assertion. Looking at how other platforms implemented the same block, I think PPC64 code is the same, and we are more or less safe with just dropping that assertion.

Additional testing:
 - [x] Linux ppc64le fastdebug, `make bootcycle-images` (now passes)
 - [x] Linux ppc64le fastdebug, `tier1` (passes modulo some environmental problems)
 - [x] Linux ppc64le fastdebug, `tier2` (passes modulo some environmental problems)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279998](https://bugs.openjdk.java.net/browse/JDK-8279998): PPC64 debug builds fail with "untested: RangeCheckStub: predicate_failed_trap_id"


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**)
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/101/head:pull/101` \
`$ git checkout pull/101`

Update a local copy of the PR: \
`$ git checkout pull/101` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/101/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 101`

View PR using the GUI difftool: \
`$ git pr show -t 101`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/101.diff">https://git.openjdk.java.net/jdk18/pull/101.diff</a>

</details>
