### PR TITLE
8280034: ProblemList jdk/jfr/api/consumer/recordingstream/TestOnEvent.java on linux-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -829,6 +829,7 @@ jdk/jfr/event/os/TestThreadContextSwitches.java                 8247776 windows-
 jdk/jfr/startupargs/TestStartName.java                          8214685 windows-x64
 jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-x64
 jdk/jfr/event/oldobject/TestLargeRootSet.java                   8276333 macosx-x64,windows-x64
+jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList jdk/jfr/api/consumer/recordingstream/TestOnEvent.java on linux-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280034](https://bugs.openjdk.java.net/browse/JDK-8280034): ProblemList jdk/jfr/api/consumer/recordingstream/TestOnEvent.java on linux-x64


### Reviewers
 * [Calvin Cheung](https://openjdk.java.net/census#ccheung) (@calvinccheung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/102/head:pull/102` \
`$ git checkout pull/102`

Update a local copy of the PR: \
`$ git checkout pull/102` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 102`

View PR using the GUI difftool: \
`$ git pr show -t 102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/102.diff">https://git.openjdk.java.net/jdk18/pull/102.diff</a>

</details>
