### PR TITLE
8280234: AArch64 "core" variant does not build after JDK-8270947

### DIFF
--- a/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
+++ b/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp
@@ -29,6 +29,7 @@
 #include "jvm.h"
 #include "asm/assembler.hpp"
 #include "asm/assembler.inline.hpp"
+#include "ci/ciEnv.hpp"
 #include "gc/shared/barrierSet.hpp"
 #include "gc/shared/barrierSetAssembler.hpp"
 #include "gc/shared/cardTableBarrierSet.hpp"


### PR DESCRIPTION
Trivial (?) fix for AArch64 build failure:

```
=== Output from failing command(s) repeated here ===
* For target hotspot_variant-core_libjvm_objs_macroAssembler_aarch64.o:
/home/shade/shipilev-jdk/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp: In member function 'u_char* MacroAssembler::zero_words(Register, Register)':
/home/shade/shipilev-jdk/src/hotspot/cpu/aarch64/macroAssembler_aarch64.cpp:4728:27: error: incomplete type 'ciEnv' used in nested name specifier
         && (task = ciEnv::current()->task())
                           ^~~~~~~ 
```

I'd like to get it to JDK 18, where it regressed, while we still at RDP1.

Additional testing:
 - [x] Linux AArch64 fastdebug core build
 - [x] Linux AArch64 fastdebug server build

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280234](https://bugs.openjdk.java.net/browse/JDK-8280234): AArch64 "core" variant does not build after JDK-8270947


### Reviewers
 * [Andrew Dinn](https://openjdk.java.net/census#adinn) (@adinn - **Reviewer**)
 * [Andrew Haley](https://openjdk.java.net/census#aph) (@theRealAph - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/108/head:pull/108` \
`$ git checkout pull/108`

Update a local copy of the PR: \
`$ git checkout pull/108` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 108`

View PR using the GUI difftool: \
`$ git pr show -t 108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/108.diff">https://git.openjdk.java.net/jdk18/pull/108.diff</a>

</details>
