### PR TITLE
8280233: Temporarily disable Unix domain sockets in Windows PipeImpl

### DIFF
--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -184,8 +184,8 @@ class PipeImpl
     /**
      * Creates Pipe implementation that supports optionally buffering.
      *
-     * @implNote The pipe uses Unix domain sockets where possible. It uses a
-     * loopback connection on older editions of Windows. When buffering is
+     * @implNote The pipe uses Unix domain sockets where possible (disabled
+     * currently on windows). It uses a loopback connection. When buffering is
      * disabled then it sets TCP_NODELAY on the sink channel.
      */
     @SuppressWarnings("removal")
@@ -212,23 +212,8 @@ class PipeImpl
         return sink;
     }
 
-    private static volatile boolean noUnixDomainSockets;
-
     private static ServerSocketChannel createListener() throws IOException {
-        ServerSocketChannel listener = null;
-        if (!noUnixDomainSockets) {
-            try {
-                listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX);
-                return listener.bind(null);
-            } catch (UnsupportedOperationException | IOException e) {
-                // IOException is most likely to be caused by the temporary directory
-                // name being too long. Possibly should log this.
-                noUnixDomainSockets = true;
-                if (listener != null)
-                    listener.close();
-            }
-        }
-        listener = ServerSocketChannel.open();
+        ServerSocketChannel listener = ServerSocketChannel.open();
         InetAddress lb = InetAddress.getLoopbackAddress();
         listener.bind(new InetSocketAddress(lb, 0));
         return listener;

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.UnixDomainSocketAddress;
 import java.net.StandardProtocolFamily;
 import java.net.StandardSocketOptions;
 import java.nio.*;
@@ -164,10 +163,6 @@ class PipeImpl
                     try {
                         if (ssc != null)
                             ssc.close();
-                        if (sa instanceof UnixDomainSocketAddress) {
-                            Path path = ((UnixDomainSocketAddress) sa).getPath();
-                            Files.deleteIfExists(path);
-                        }
                     } catch (IOException e2) {}
                 }
             }

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -184,8 +184,7 @@ class PipeImpl
     /**
      * Creates Pipe implementation that supports optionally buffering.
      *
-     * @implNote The pipe uses Unix domain sockets where possible (disabled
-     * currently on windows). It uses a loopback connection. When buffering is
+     * @implNote Uses a loopback connection. When buffering is
      * disabled then it sets TCP_NODELAY on the sink channel.
      */
     @SuppressWarnings("removal")

--- a/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
+++ b/src/java.base/windows/classes/sun/nio/ch/PipeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.StandardProtocolFamily;
 import java.net.StandardSocketOptions;
 import java.nio.*;
 import java.nio.channels.*;


### PR DESCRIPTION
Hi,

Could I get the following change reviewed please? Pending full investigation of the cause of (JDK-8278369) we want to disable the use of Unix domain sockets in the Windows Pipe implementation, reverting to the previous (pre JDK 16) TCP socket impl. The TCP impl was always used in versions of windows other than 10, 2019 server+ that didn't support Unix domain sockets. There isn't a regression test as existing Pipe tests should be sufficient.

It's not clear at this point if the issue is a JDK or Windows bug but it's expected the Unix domain impl will be restored later. UNIX protocol family SocketChannel/ServerSocketChannels still work after this change.  

Thanks,

Michael.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280233](https://bugs.openjdk.java.net/browse/JDK-8280233): Temporarily disable Unix domain sockets in Windows PipeImpl


### Reviewers
 * [Alan Bateman](https://openjdk.java.net/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/109/head:pull/109` \
`$ git checkout pull/109`

Update a local copy of the PR: \
`$ git checkout pull/109` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/109/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 109`

View PR using the GUI difftool: \
`$ git pr show -t 109`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/109.diff">https://git.openjdk.java.net/jdk18/pull/109.diff</a>

</details>
