### PR TITLE
8278834: Error "Cannot read field "sym" because "this.lvar[od]" is null" when compiling

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -665,11 +665,14 @@ public class TransPatterns extends TreeTranslator {
     @Override
     public void visitClassDef(JCClassDecl tree) {
         ClassSymbol prevCurrentClass = currentClass;
+        MethodSymbol prevMethodSym = currentMethodSym;
         try {
             currentClass = tree.sym;
+            currentMethodSym = null;
             super.visitClassDef(tree);
         } finally {
             currentClass = prevCurrentClass;
+            currentMethodSym = prevMethodSym;
         }
     }
 

--- a/test/langtools/tools/javac/patterns/BindingsInitializer.java
+++ b/test/langtools/tools/javac/patterns/BindingsInitializer.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8278834
+ * @summary Verify pattern matching nested inside initializers of classes nested in methods
+ *          works correctly.
+ * @library /tools/lib /tools/javac/lib
+ * @modules
+ *      jdk.compiler/com.sun.tools.javac.api
+ *      jdk.compiler/com.sun.tools.javac.file
+ *      jdk.compiler/com.sun.tools.javac.main
+ *      jdk.compiler/com.sun.tools.javac.util
+ * @build toolbox.ToolBox toolbox.JavacTask
+ * @build combo.ComboTestHelper
+ * @compile BindingsInitializer.java
+ * @run main BindingsInitializer
+ */
+
+import combo.ComboInstance;
+import combo.ComboParameter;
+import combo.ComboTask;
+import combo.ComboTestHelper;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import toolbox.ToolBox;
+
+public class BindingsInitializer extends ComboInstance<BindingsInitializer> {
+    protected ToolBox tb;
+
+    BindingsInitializer() {
+        super();
+        tb = new ToolBox();
+    }
+
+    public static void main(String... args) throws Exception {
+        new ComboTestHelper<BindingsInitializer>()
+                .withDimension("OUTER", (x, outer) -> x.outer = outer, Outer.values())
+                .withDimension("MIDDLE", (x, middle) -> x.middle = middle, Middle.values())
+                .withDimension("INNER", (x, inner) -> x.inner = inner, Inner.values())
+                .withDimension("TEST", (x, test) -> x.test = test, Test.values())
+                .run(BindingsInitializer::new);
+    }
+
+    private Outer outer;
+    private Middle middle;
+    private Inner inner;
+    private Test test;
+
+    private static final String MAIN_TEMPLATE =
+            """
+            public class Test {
+                private static Object obj = "";
+                #{OUTER}
+            }
+            """;
+
+    @Override
+    protected void doWork() throws Throwable {
+        Path base = Paths.get(".");
+
+        ComboTask task = newCompilationTask()
+                .withSourceFromTemplate(MAIN_TEMPLATE, pname -> switch (pname) {
+                        case "OUTER" -> outer;
+                        case "MIDDLE" -> middle;
+                        case "INNER" -> inner;
+                        case "TESST" -> test;
+                        default -> throw new UnsupportedOperationException(pname);
+                    });
+
+        task.generate(result -> {
+            if (result.hasErrors()) {
+                throw new AssertionError("Unexpected result: " + result.compilationInfo());
+            }
+        });
+    }
+
+    public enum Outer implements ComboParameter {
+        NONE("#{MIDDLE}"),
+        STATIC_CLASS("static class Nested { #{MIDDLE} }"),
+        CLASS("class Inner { #{MIDDLE} }");
+        private final String code;
+
+        private Outer(String code) {
+            this.code = code;
+        }
+
+        @Override
+        public String expand(String optParameter) {
+            return code;
+        }
+    }
+
+    public enum Middle implements ComboParameter {
+        STATIC_INIT("static { #{INNER} }"),
+        INIT("{ #{INNER} }"),
+        METHOD("void test() { #{INNER} }");
+        private final String code;
+
+        private Middle(String code) {
+            this.code = code;
+        }
+
+        @Override
+        public String expand(String optParameter) {
+            return code;
+        }
+    }
+
+    public enum Inner implements ComboParameter {
+        DIRECT("#{TEST}"),
+        CLASS_STATIC_INIT("class C { static { #{TEST} } }"),
+        CLASS_INIT("class C { { #{TEST} } }"),
+        CLASS_METHOD("class C { void t() { #{TEST} } }"),
+        ANNONYMOUS_CLASS_STATIC_INIT("new Object() { static { #{TEST} } };"),
+        ANNONYMOUS_CLASS_INIT("new Object() { { #{TEST} } };"),
+        ANNONYMOUS_CLASS_METHOD("new Object() { void t() { #{TEST} } };");
+        private final String code;
+
+        private Inner(String code) {
+            this.code = code;
+        }
+
+        @Override
+        public String expand(String optParameter) {
+            return code;
+        }
+    }
+
+    public enum Test implements ComboParameter {
+        TEST("if (obj instanceof String str) System.err.println(str);");
+        private final String code;
+
+        private Test(String code) {
+            this.code = code;
+        }
+
+        @Override
+        public String expand(String optParameter) {
+            return code;
+        }
+    }
+}


### PR DESCRIPTION
For code like:
```
public class TestInstanceOf {

    public static void main(String[] args) {
        Number abc = 1;
        new Object() {
            {
                if (abc instanceof Integer integer) {
                    System.out.println(integer.intValue());
                }
            }
        };
    }

}
```

`javac` crashes with:
```
An exception has occurred in the compiler (17-internal). Please file a bug against the Java compiler via the Java bug reporting page (http://bugreport.java.com) after checking the Bug Database (http://bugs.java.com) for duplicates. Include your program, the following diagnostic, and the parameters passed to the Java compiler in your report. Thank you.
java.lang.NullPointerException: Cannot read field "sym" because "this.lvar[3]" is null
        at jdk.compiler/com.sun.tools.javac.jvm.Code.emitop0(Code.java:577)
        at jdk.compiler/com.sun.tools.javac.jvm.Items$LocalItem.load(Items.java:399)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.genArgs(Gen.java:902)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.visitNewClass(Gen.java:1961)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCNewClass.accept(JCTree.java:1852)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.genExpr(Gen.java:877)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.visitExec(Gen.java:1742)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCExpressionStatement.accept(JCTree.java:1584)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.genDef(Gen.java:610)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.genStat(Gen.java:645)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.genStat(Gen.java:631)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.genStats(Gen.java:682)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.visitBlock(Gen.java:1097)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCBlock.accept(JCTree.java:1091)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.genDef(Gen.java:610)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.genStat(Gen.java:645)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.genMethod(Gen.java:967)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.visitMethodDef(Gen.java:930)
        at jdk.compiler/com.sun.tools.javac.tree.JCTree$JCMethodDecl.accept(JCTree.java:921)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.genDef(Gen.java:610)
        at jdk.compiler/com.sun.tools.javac.jvm.Gen.genClass(Gen.java:2414)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.genCode(JavaCompiler.java:737)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.generate(JavaCompiler.java:1617)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.generate(JavaCompiler.java:1585)
        at jdk.compiler/com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:946)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:317)
        at jdk.compiler/com.sun.tools.javac.main.Main.compile(Main.java:176)
        at jdk.compiler/com.sun.tools.javac.Main.compile(Main.java:64)
        at jdk.compiler/com.sun.tools.javac.Main.main(Main.java:50)
```

The cause is in `TransPatterns` - it tracks the current class and method, so that it can define correct owners for temporary variables. But if there's a class nested in a method, the current method field is not cleared, and consequently the temporary variables get a wrong owner (the method enclosing the class, not a method inside the current class), which then crashes subsequent phases, like Gen.

The proposed fix is to clear `currentMethod` when entering a class AST node.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278834](https://bugs.openjdk.java.net/browse/JDK-8278834): Error "Cannot read field "sym" because "this.lvar[od]" is null" when compiling


### Reviewers
 * [Vicente Romero](https://openjdk.java.net/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/110.diff">https://git.openjdk.java.net/jdk18/pull/110.diff</a>

</details>
