### PR TITLE
JDK-8279179: Update nroff pages in JDK 18 before RC

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -512,6 +512,15 @@ of the release.
 .RS
 .RE
 .TP
+.B \f[CB]\-\-finalization=\f[R]\f[I]value\f[R]
+Controls whether the JVM performs finalization of objects.
+Valid values are "enabled" and "disabled".
+Finalization is enabled by default, so the value "enabled" does nothing.
+The value "disabled" disables finalization, so that no finalizers are
+invoked.
+.RS
+.RE
+.TP
 .B \f[CB]\-\-module\-path\f[R] \f[I]modulepath\f[R]... or \f[CB]\-p\f[R] \f[I]modulepath\f[R]
 A semicolon (\f[CB];\f[R]) separated list of directories in which each
 directory is a directory of modules.

--- a/src/java.base/share/man/keytool.1
+++ b/src/java.base/share/man/keytool.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1998, 2020, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -70,6 +70,8 @@ keystore
 \f[CB]\-storepasswd\f[R]: Changes the store password of a keystore
 .IP \[bu] 2
 \f[CB]\-showinfo\f[R]: Displays security\-related information
+.IP \[bu] 2
+\f[CB]\-version\f[R]: Prints the program version
 .PP
 See \f[B]Commands and Options\f[R] for a description of these commands
 with their options.
@@ -219,6 +221,10 @@ they perform.
 \f[B]Commands for Displaying Security\-related Information\f[R]:
 .IP \[bu] 2
 \f[CB]\-showinfo\f[R]
+.PP
+\f[B]Commands for Displaying Program Version\f[R]:
+.IP \[bu] 2
+\f[CB]\-version\f[R]
 .SH COMMANDS FOR CREATING OR ADDING DATA TO THE KEYSTORE
 .TP
 .B \f[CB]\-gencert\f[R]
@@ -1314,6 +1320,10 @@ information.
 The \f[CB]\-tls\f[R] option displays TLS configurations, such as the list
 of enabled protocols and cipher suites.
 .RE
+.SH COMMANDS FOR DISPLAYING PROGRAM VERSION
+.PP
+You can use \f[CB]\-version\f[R] to print the program version of
+\f[CB]keytool\f[R].
 .SH COMMANDS FOR DISPLAYING HELP INFORMATION
 .PP
 You can use \f[CB]\-\-help\f[R] to display a list of \f[CB]keytool\f[R]

--- a/src/jdk.jartool/share/man/jarsigner.1
+++ b/src/jdk.jartool/share/man/jarsigner.1
@@ -1,4 +1,4 @@
-.\" Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+.\" Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
 .\" DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 .\"
 .\" This code is free software; you can redistribute it and/or modify it
@@ -33,6 +33,8 @@ jarsigner \- sign and verify Java Archive (JAR) files
 .PP
 \f[CB]jarsigner\f[R] \f[CB]\-verify\f[R] [\f[I]options\f[R]]
 \f[I]jar\-file\f[R] [\f[I]alias\f[R] ...]
+.PP
+\f[CB]jarsigner\f[R] \f[CB]\-version\f[R]
 .TP
 .B \f[I]options\f[R]
 The command\-line options.
@@ -67,6 +69,12 @@ signed, with signer errors" is displayed.
 .B \f[I]alias\f[R]
 The aliases are defined in the keystore specified by \f[CB]\-keystore\f[R]
 or the default keystore.
+.RS
+.RE
+.TP
+.B \f[CB]\-version\f[R]
+The \f[CB]\-version\f[R] option prints the program version of
+\f[CB]jarsigner\f[R].
 .RS
 .RE
 .SH DESCRIPTION
@@ -1077,6 +1085,11 @@ The property keys supported are "jarsigner.all" for all actions,
 "jarsigner.sign" for signing, and "jarsigner.verify" for verification.
 \f[CB]jarsigner\f[R] arguments including the JAR file name and alias
 name(s) cannot be set in this file.
+.RS
+.RE
+.TP
+.B \f[CB]\-version\f[R]
+Prints the program version.
 .RS
 .RE
 .SH DEPRECATED OPTIONS


### PR DESCRIPTION
Please review this semi-automated update to the nroff man pages from the upstream repo.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279179](https://bugs.openjdk.java.net/browse/JDK-8279179): Update nroff pages in JDK 18 before RC


### Reviewers
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jdk18 pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.java.net/jdk18 pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jdk18/pull/112.diff">https://git.openjdk.java.net/jdk18/pull/112.diff</a>

</details>
